### PR TITLE
Added (European) Portuguese translation

### DIFF
--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+	<string name="could_not_get_videos">Não foi possível obter os vídeos de %s.</string>
+	<string name="views">%,d visualizações</string>
+	<string name="error">Erro</string>
+	<string name="ok">Ok</string>
+	<string name="search_videos">Pesquisar Vídeos</string>
+	<string name="launch_offical_player_error">Ocorreu um erro ao tentar iniciar o
+		reprodutor oficial do YouTube. Certifique-se de que a aplicação oficial do YouTube do Google 
+		está instalada no seu dispositivo.</string>
+	<string name="LIVE">Direto</string>
+
+	<string name="featured">Destaque</string>
+	<string name="most_popular">Mais popular</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_bookmarks.xml
+++ b/app/src/main/res/values-pt-rPT/strings_bookmarks.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="bookmarks">Marcadores</string>
+
+	<string name="bookmark">Adicionar aos marcadores</string>
+	<string name="video_bookmarked">Vídeo adicionado aos marcadores</string>
+	<string name="video_bookmarked_error">Não foi possível adicionar vídeo aos marcadores.</string>
+
+	<string name="unbookmark">Removido dos marcadores</string>
+	<string name="video_unbookmarked">Vídeo dos marcadores</string>
+	<string name="video_unbookmarked_error">Não foi possível remover vídeo dos marcadores.</string>
+
+	<string name="no_bookmarked_videos_text">Ainda não adicionou nenhum vídeo aos marcadores.\n\nAssim que o fizer, eles apareceram aqui.</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_feed.xml
+++ b/app/src/main/res/values-pt-rPT/strings_feed.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="feed">Feed</string>
+
+	<string name="fetching_subscription_videos">A obter vídeos de canais subscritos</string>
+	<string name="fetched_videos_from_channels">A obter %1$d vídeos de %2$d/%3$d canais.</string>
+	<string name="no_new_videos_found">Não foram encontrados novos vídeos.</string>
+	<string name="no_subscriptions_text">Ainda não subscreveu nenhum canal.\n\nAssim que o fizer, todos os vídeos enviados para os seus canais subscritos no último mês aparecerão aqui.</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_preferences.xml
+++ b/app/src/main/res/values-pt-rPT/strings_preferences.xml
@@ -1,0 +1,420 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="preferences">Preferências</string>
+
+	<string name="pref_languages_category">Línguas &amp; Regiões</string>
+	<string name="pref_title_preferred_regions">Preferência de Região</string>
+	<string name="pref_key_preferred_region">pref_key_preferred_region</string>
+	<string name="pref_summary_preferred_regions">Selecione uma região preferida. Isso é usado para filtrar vídeos na categoria de vídeos \"Destaque\".</string>
+
+	<string name="pref_title_preferred_languages">Preferência de Língua(s)</string>
+	<string name="pref_key_preferred_languages">pref_key_preferred_languages</string>
+	<string name="pref_summary_preferred_languages">EXPERIMENTAL: Selecione uma ou mais línguas preferidas. Isso é usado para filtrar vídeos na categoria de vídeo \"Mais Popular\" e para pesquisas de vídeo.</string>
+
+	<string name="pref_video_player_category">Reprodutor de Vídeo</string>
+	<string name="pref_key_video_player_category">video_player_category</string>
+	<string name="pref_title_preferred_res">Resolução Preferida</string>
+	<string name="pref_key_preferred_res">pref_preferred_resolution</string>
+	<string name="pref_summary_preferred_res">Selecione a sua resolução preferida</string>
+	<string name="pref_title_use_offical_player">Utilizar o reprodutor oficial do YouTube</string>
+	<string name="pref_key_use_offical_player">pref_use_official_youtube_player</string>
+	<string name="pref_summary_use_offical_player">Não recomendado</string>
+
+	<string name="pref_about_category">Sobre</string>
+	<string name="pref_title_website">Website</string>
+	<string name="pref_key_website">pref_website</string>
+	<string name="pref_title_credits">Créditos</string>
+	<string name="pref_key_credits">pref_credits</string>
+	<string name="pref_summary_credits">Pessoas e projetos que tornaram esta aplicação possível.</string>
+	<string name="pref_title_version">Versão</string>
+	<string name="pref_key_version">pref_version</string>
+	<string name="pref_title_license">Licença</string>
+	<string name="pref_key_license">pref_license</string>
+	<string name="pref_summary_license">GNU General Public License version 3</string>
+	<string name="app_license">
+		Copyright &#169; 2015-2017  Ramon Mifsud\n
+
+		\nThis program is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation (version 3 of the License).\n
+
+		\nThis program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.\n
+
+		\nYou should have received a copy of the GNU General Public License
+		along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;
+	</string>
+	<string name="i_agree">Concordo</string>
+
+
+	<string-array name="languages_names">
+		<item>Afrikaans</item>
+		<item>Azərbaycan</item>
+		<item>Bahasa Indonesia</item>
+		<item>Bahasa Malaysia</item>
+		<item>Català</item>
+		<item>Čeština</item>
+		<item>Dansk</item>
+		<item>Deutsch</item>
+		<item>Eesti</item>
+		<item>English (UK)</item>
+		<item>English (US)</item>
+		<item>Español (España)</item>
+		<item>Español (Latinoamérica)</item>
+		<item>Euskara</item>
+		<item>Filipino</item>
+		<item>Français</item>
+		<item>Français (Canada)</item>
+		<item>Galego</item>
+		<item>Hrvatski</item>
+		<item>IsiZulu</item>
+		<item>Íslenska</item>
+		<item>Italiano</item>
+		<item>Kiswahili</item>
+		<item>Latviešu valoda</item>
+		<item>Lietuvių</item>
+		<item>Magyar</item>
+		<item>Nederlands</item>
+		<item>Norsk</item>
+		<item>O‘zbek</item>
+		<item>Polski</item>
+		<item>Português</item>
+		<item>Português (Brasil)</item>
+		<item>Română</item>
+		<item>Shqip</item>
+		<item>Slovenčina</item>
+		<item>Slovenščina</item>
+		<item>Suomi</item>
+		<item>Svenska</item>
+		<item>Tiếng Việt</item>
+		<item>Türkçe</item>
+		<item>Български</item>
+		<item>Кыргызча</item>
+		<item>Қазақ Тілі</item>
+		<item>Македонски</item>
+		<item>Монгол</item>
+		<item>Русский</item>
+		<item>Српски</item>
+		<item>Українська</item>
+		<item>Ελληνικά</item>
+		<item>Հայերեն</item>
+		<item>עברית</item>
+		<item>اردو</item>
+		<item>العربية</item>
+		<item>فارسی</item>
+		<item>नेपाली</item>
+		<item>मराठी</item>
+		<item>हिन्दी</item>
+		<item>বাংলা</item>
+		<item>ਪੰਜਾਬੀ</item>
+		<item>ગુજરાતી</item>
+		<item>தமிழ்</item>
+		<item>తెలుగు</item>
+		<item>ಕನ್ನಡ</item>
+		<item>മലയാളം</item>
+		<item>සිංහල</item>
+		<item>ภาษาไทย</item>
+		<item>ລາວ</item>
+		<item>ဗမာ</item>
+		<item>ქართული</item>
+		<item>አማርኛ</item>
+		<item>ខ្មែរ</item>
+		<item>中文 (简体)</item>
+		<item>中文 (繁體)</item>
+		<item>中文 (香港)</item>
+		<item>日本語</item>
+		<item>한국어</item>
+	</string-array>
+
+	<string-array name="languages_iso639_codes">
+		<item>af</item>
+		<item>az</item>
+		<item>id</item>
+		<item>ms</item>
+		<item>ca</item>
+		<item>cs</item>
+		<item>da</item>
+		<item>de</item>
+		<item>et</item>
+		<item>en-GB</item>
+		<item>"en(?:-US)?"</item>	<!-- "en" or "en-US" -->
+		<item>es</item>
+		<item>es-419</item>
+		<item>eu</item>
+		<item>fil</item>
+		<item>fr</item>
+		<item>fr-CA</item>
+		<item>gl</item>
+		<item>hr</item>
+		<item>zu</item>
+		<item>is</item>
+		<item>it</item>
+		<item>sw</item>
+		<item>lv</item>
+		<item>lt</item>
+		<item>hu</item>
+		<item>nl</item>
+		<item>no</item>
+		<item>uz</item>
+		<item>pl</item>
+		<item>pt-PT</item>
+		<item>pt</item>
+		<item>ro</item>
+		<item>sq</item>
+		<item>sk</item>
+		<item>sl</item>
+		<item>fi</item>
+		<item>sv</item>
+		<item>vi</item>
+		<item>tr</item>
+		<item>bg</item>
+		<item>ky</item>
+		<item>kk</item>
+		<item>mk</item>
+		<item>mn</item>
+		<item>ru</item>
+		<item>sr</item>
+		<item>uk</item>
+		<item>el</item>
+		<item>hy</item>
+		<item>iw</item>
+		<item>ur</item>
+		<item>ar</item>
+		<item>fa</item>
+		<item>ne</item>
+		<item>mr</item>
+		<item>hi</item>
+		<item>bn</item>
+		<item>pa</item>
+		<item>gu</item>
+		<item>ta</item>
+		<item>te</item>
+		<item>kn</item>
+		<item>ml</item>
+		<item>si</item>
+		<item>th</item>
+		<item>lo</item>
+		<item>my</item>
+		<item>ka</item>
+		<item>am</item>
+		<item>km</item>
+		<item>zh-CN</item>
+		<item>zh-TW</item>
+		<item>zh-HK</item>
+		<item>ja</item>
+		<item>ko</item>
+	</string-array>
+
+
+	<!-- NB for Translators:  Country names shall all be written in English -->
+	<string-array name="country_names">
+		<item>Worldwide (All)</item>
+		<item>Algeria</item>
+		<item>Argentina</item>
+		<item>Australia</item>
+		<item>Austria</item>
+		<item>Azerbaijan</item>
+		<item>Bahrain</item>
+		<item>Belarus</item>
+		<item>Belgium</item>
+		<item>Bosnia and Herzegovina</item>
+		<item>Brazil</item>
+		<item>Bulgaria</item>
+		<item>Canada</item>
+		<item>Chile</item>
+		<item>Colombia</item>
+		<item>Croatia</item>
+		<item>Czech Republic</item>
+		<item>Denmark</item>
+		<item>Egypt</item>
+		<item>Estonia</item>
+		<item>Finland</item>
+		<item>France</item>
+		<item>Georgia</item>
+		<item>Germany</item>
+		<item>Ghana</item>
+		<item>Greece</item>
+		<item>Hong Kong</item>
+		<item>Hungary</item>
+		<item>Iceland</item>
+		<item>India</item>
+		<item>Indonesia</item>
+		<item>Iraq</item>
+		<item>Ireland</item>
+		<item>Israel</item>
+		<item>Italy</item>
+		<item>Japan</item>
+		<item>Jordan</item>
+		<item>Kazakhstan</item>
+		<item>Kenya</item>
+		<item>Kuwait</item>
+		<item>Latvia</item>
+		<item>Lebanon</item>
+		<item>Libya</item>
+		<item>Lithuania</item>
+		<item>Luxembourg</item>
+		<item>Macedonia</item>
+		<item>Malaysia</item>
+		<item>Mexico</item>
+		<item>Montenegro</item>
+		<item>Morocco</item>
+		<item>Nepal</item>
+		<item>Netherlands</item>
+		<item>New Zealand</item>
+		<item>Nigeria</item>
+		<item>Norway</item>
+		<item>Oman</item>
+		<item>Pakistan</item>
+		<item>Peru</item>
+		<item>Philippines</item>
+		<item>Poland</item>
+		<item>Portugal</item>
+		<item>Puerto Rico</item>
+		<item>Qatar</item>
+		<item>Romania</item>
+		<item>Russia</item>
+		<item>Saudi Arabia</item>
+		<item>Senegal</item>
+		<item>Serbia</item>
+		<item>Singapore</item>
+		<item>Slovakia</item>
+		<item>Slovenia</item>
+		<item>South Africa</item>
+		<item>South Korea</item>
+		<item>Spain</item>
+		<item>Sri Lanka</item>
+		<item>Sweden</item>
+		<item>Switzerland</item>
+		<item>Taiwan</item>
+		<item>Tanzania</item>
+		<item>Thailand</item>
+		<item>Tunisia</item>
+		<item>Turkey</item>
+		<item>Uganda</item>
+		<item>Ukraine</item>
+		<item>United Arab Emirates</item>
+		<item>United Kingdom</item>
+		<item>Vietnam</item>
+		<item>Yemen</item>
+		<item>Zimbabwe</item>
+	</string-array>
+
+	<string-array name="country_codes">
+		<item></item>
+		<item>DZ</item>
+		<item>AR</item>
+		<item>AU</item>
+		<item>AT</item>
+		<item>AZ</item>
+		<item>BH</item>
+		<item>BY</item>
+		<item>BE</item>
+		<item>BA</item>
+		<item>BR</item>
+		<item>BG</item>
+		<item>CA</item>
+		<item>CL</item>
+		<item>CO</item>
+		<item>HR</item>
+		<item>CZ</item>
+		<item>DK</item>
+		<item>EG</item>
+		<item>EE</item>
+		<item>FI</item>
+		<item>FR</item>
+		<item>GE</item>
+		<item>DE</item>
+		<item>GH</item>
+		<item>GR</item>
+		<item>HK</item>
+		<item>HU</item>
+		<item>IS</item>
+		<item>IN</item>
+		<item>ID</item>
+		<item>IQ</item>
+		<item>IE</item>
+		<item>IL</item>
+		<item>IT</item>
+		<item>JP</item>
+		<item>JO</item>
+		<item>KZ</item>
+		<item>KE</item>
+		<item>KW</item>
+		<item>LV</item>
+		<item>LB</item>
+		<item>LY</item>
+		<item>LT</item>
+		<item>LU</item>
+		<item>MK</item>
+		<item>MY</item>
+		<item>MX</item>
+		<item>ME</item>
+		<item>MA</item>
+		<item>NP</item>
+		<item>NL</item>
+		<item>NZ</item>
+		<item>NG</item>
+		<item>NO</item>
+		<item>OM</item>
+		<item>PK</item>
+		<item>PE</item>
+		<item>PH</item>
+		<item>PL</item>
+		<item>PT</item>
+		<item>PR</item>
+		<item>QA</item>
+		<item>RO</item>
+		<item>RU</item>
+		<item>SA</item>
+		<item>SN</item>
+		<item>RS</item>
+		<item>SG</item>
+		<item>SK</item>
+		<item>SI</item>
+		<item>ZA</item>
+		<item>KR</item>
+		<item>ES</item>
+		<item>LK</item>
+		<item>SE</item>
+		<item>CH</item>
+		<item>TW</item>
+		<item>TZ</item>
+		<item>TH</item>
+		<item>TN</item>
+		<item>TR</item>
+		<item>UG</item>
+		<item>UA</item>
+		<item>AE</item>
+		<item>GB</item>
+		<item>VN</item>
+		<item>YE</item>
+		<item>ZW</item>
+	</string-array>
+
+	<string name="pref_other_category">Outros</string>
+	<string name="pref_key_default_tab">pref_default_tab</string>
+	<string name="pref_title_default_tab">Separador Padrão</string>
+	<string name="pref_summary_default_tab">Separador inicial ao iniciar o SkyTube: %s</string>
+	<string-array name="default_tab">
+		<item>@string/featured</item>
+		<item>@string/most_popular</item>
+		<item>@string/feed</item>
+		<item>@string/bookmarks</item>
+	</string-array>
+	<string-array name="default_tab_values">
+		<item>0</item>
+		<item>1</item>
+		<item>2</item>
+		<item>3</item>
+	</string-array>
+
+	<string name="pref_youtube_api_key">pref_youtube_api_key</string>
+	<string name="pref_title_youtube_api_key">Chave API do YouTube</string>
+	<string name="pref_summary_youtube_api_key">Introduza a sua própria chave da API de dados do YouTube.  Deixe em branco para usar o padrão.</string>
+	<string name="pref_youtube_api_key_error">Ocorreu um erro ao tentar validar a chave da API introduzida.</string>
+	<string name="pref_youtube_api_key_custom">A chave é válida.  Reinicie a aplicação para usar a nova chave da API do YouTube.</string>
+	<string name="pref_youtube_api_key_default">Reinicie a aplicação para retornar à chave padrão da API do YouTube.</string>
+	<string name="restart">Reiniciar</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_subs.xml
+++ b/app/src/main/res/values-pt-rPT/strings_subs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="subscriptions">Subscrições</string>
+	<string name="subscribe">Subscrito</string>
+	<string name="unsubscribe">Anular Subscrição</string>
+	<string name="total_subscribers">%,d subscritos</string>
+
+	<string name="subscribed">Subscrito</string>
+	<string name="unsubscribed">Subscrição Anulada</string>
+
+	<string name="error_get_subbed_channels">Ocorreu um erro ao obter canais subscritos.</string>
+	<string name="error_check_if_user_has_subbed">Não foi possível verificar se o utilizador subscreveu o canal (id=%s)</string>
+	<string name="error_unable_to_subscribe">Não é possível anular\/subscrever o canal (id=%s)</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_updater.xml
+++ b/app/src/main/res/values-pt-rPT/strings_updater.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="update_available">Atualização Disponível</string>
+	<string name="update_dialog_msg">Está disponível uma nova atualização do SkyTube. A aplicação será atualizada para a versão %s.</string>
+	<string name="update">Atualizar</string>
+	<string name="later">Mais tarde</string>
+	<string name="update_failure">Não foi possível atualizar a aplicação.</string>
+	<string name="downloading">A transferir…</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings_youtube_player.xml
+++ b/app/src/main/res/values-pt-rPT/strings_youtube_player.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="error_stream_err_unavailable">Mensagem de erro não está disponível.</string>
+	<string name="error_stream_decryption_fail">Não foi possível carregar o código de desencriptação para o serviço do Youtube.</string>
+	<string name="error_stream_parse_error">Parsing error.</string>
+
+	<string name="error_video_play">Mostrar erro do vídeo</string>
+	<string name="error_video_streams_empty">O vídeo %s não tem emissões!</string>
+	<string name="error_get_video_desc">Ocorreu um erro ao obter a descrição do vídeo.</string>
+	<string name="error_invalid_url">URL de vídeo invalido: %s</string>
+
+	<string name="warning_live_video">Não é possível reproduzir emissões em direto agora.  Abrir emissão externamente?</string>
+
+	<string name="ratings_disabled">Ratings disabled</string>
+
+	<string name="loading_video">A carregar vídeo…</string>
+	<string name="get_new_video_steam">Nova emissão</string>
+	<string name="open_in_browser">Abrir no navegador</string>
+	<string name="open_with">Abrir com…</string>
+	<string name="share">Partilhar</string>
+	<string name="share_via">Partilhar via</string>
+	<string name="copy_url">Copiar URL</string>
+	<string name="url_copied_to_clipboard">URL copiado para a área de transferência.</string>
+
+	<string name="error_get_comments">Ocorreu um erro ao obter os comentários.</string>
+	<string name="no_video_comments">Este video não tem comentários ou estão desativados.</string>
+	<string name="view_replies">Ver respostas</string>
+	<string name="hide_replies">Ocultar respostas</string>
+
+	<string name="enter_video_url">Escrever URL do vídeo</string>
+	<string name="play">Reproduzir</string>
+	<string name="cancel">Cancelar</string>
+	<string name="clear">Limpar</string>
+</resources>


### PR DESCRIPTION
Consider in the future adding skytube on a translation service like transifex, weblate, crowdin or other. 
For contributors easier access.

I've added an escape on "error_unable_to_subscribe", tell me if that's correct or if need to change
`Não é possível anular\/subscrever o canal (id=%s)`