### PR TITLE
Fixed bug introduced in import subscriptions feature that caused the …

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/GetSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/GetSubscriptionVideosTask.java
@@ -150,6 +150,8 @@ public class GetSubscriptionVideosTask extends AsyncTaskParallel<Void, Void, Voi
 					tasks.get(0).executeInParallel();
 					tasks.remove(0);
 				}
+				if(listener != null)
+					listener.onChannelVideosFetched(channel, youTubeVideos != null ? youTubeVideos.size() : 0, videosDeleted);
 			} else {
 				videosDeleted = SubscriptionsDb.getSubscriptionsDb().trimSubscriptionVideos();
 				// All channels have finished querying. Update the last time this refresh was done.
@@ -161,8 +163,6 @@ public class GetSubscriptionVideosTask extends AsyncTaskParallel<Void, Void, Voi
 				if(listener != null)
 					listener.onAllChannelVideosFetched();
 			}
-			if(listener != null)
-				listener.onChannelVideosFetched(channel, youTubeVideos != null ? youTubeVideos.size() : 0, videosDeleted);
 		}
 
 


### PR DESCRIPTION
…count of the number of channels for which videos were fetched to be increased an extra time.

So context:when I wrote the Import Subscriptions feature, `SubscriptionsBackupManager` would call `SubscriptionsFragmentListener.onAllChannelVideosFetched` (when videos for all the imported channels were finished importing), which displays a Toast showing how many channels had been processed. `GetSubscriptionVideosTask` needs to call `SubscriptionsFragmentListener.onChannelVideosFetched` before then, though, so the total number of channels would be increased (to the maximum number of channels that were being imported) before `SubscriptionsFragmentListener.onAllChannelVideosFetched`, so that that method can have the correct count of channels processed. I had incorrectly copied the call to `SubscriptionsFragmentListener.onChannelVideosFetched`, without moving the later call to it above, so that it wouldn't get called twice for the same task.

This bug was resulting in the dialog displaying something like "Fetched # videos from 34/33 channels.", when it should have finished at 33/33 (when there were in fact only 33 channels subscribed).