### PR TITLE
Updated gradle to version 3, and all included libraries to their late…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,18 +28,21 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    flavorDimensions "skytube"
     productFlavors {
         // 100% Open-Source Edition
         oss {
             applicationId "free.rm.skytube.oss"
             versionName "2.691 Beta"          // the digits of the *fractional part* shall not be larger than "9"
             resValue "string", "app_name", "SkyTube"
+            dimension "skytube"
         }
         // 99% Open-source edition:  uses the YouTube Player Jar [i.e. proprietary module - optional usage]
         extra {
             applicationId "free.rm.skytube.extra"
             versionName "2.691 Beta Extra"    // the digits of the *fractional part* shall not be larger than "9"
             resValue "string", "app_name", "SkyTube Extra"
+            dimension "skytube"
         }
     }
 }
@@ -76,5 +79,7 @@ dependencies {
     compile 'com.android.support:design:26.1.0'
     compile 'com.android.support:recyclerview-v7:26.1.0'
     compile 'com.android.support:cardview-v7:26.1.0'
-    compile 'com.android.support:multidex:1.0.1'    // this is as we have over 65536 lines of code...
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:design:26.1.0'
+    compile 'com.android.support:multidex:1.0.2'    // this is as we have over 65536 lines of code...
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,5 @@ dependencies {
     compile 'com.android.support:design:26.1.0'
     compile 'com.android.support:recyclerview-v7:26.1.0'
     compile 'com.android.support:cardview-v7:26.1.0'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
     compile 'com.android.support:multidex:1.0.2'    // this is as we have over 65536 lines of code...
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,6 +18,7 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
         google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Mar 19 16:38:25 CET 2017
+#Sat Sep 23 10:41:24 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
…st versions. Gradle update fixes crash when executing search.

I'll note that this requires using Android Studio 3 (currently Beta 6) - Android Studio 2 will not complete a gradle sync, it looks like it doesn't like gradle version 4.x.

The updates to the java files were due to using the latest version of Butterknife, which changes the annotation from @Bind to @BindView.