### PR TITLE
Fixed regression that caused the Feed tab to not update with videos f…

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscribeButton.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscribeButton.java
@@ -56,7 +56,8 @@ public class SubscribeButton extends AppCompatButton implements View.OnClickList
 		if(externalClickListener != null) {
 			externalClickListener.onClick(SubscribeButton.this);
 		}
-		if(fetchChannelVideosOnSubscribe) {
+		// Only fetch videos for this channel if fetchChannelVideosOnSubscribe is true AND the channel is not subscribed to yet.
+		if(fetchChannelVideosOnSubscribe && !isUserSubscribed) {
 			new GetChannelVideosTask(channel).executeInParallel();
 		}
 		if(channel != null)

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscriptionsBackupsManager.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscriptionsBackupsManager.java
@@ -237,6 +237,14 @@ public class SubscriptionsBackupsManager {
 
 	}
 
+	/**
+	 * Parse the XML file that the user selected to import subscriptions from. Each channel contained in the XML
+	 * that the user is not already subscribed to will appear in a dialog, to allow the user to select individual channels
+	 * to subscribe to, via a new Dialog. Once the user chooses to import the selected channels via the Import Subscriptions
+	 * button, {@link SubscribeToImportedChannelsTask} will be executed with a list of the selected channels.
+	 *
+	 * @param uri The URI pointing to the XML file containing YouTube Channels to subscribe to.
+	 */
 	private void parseImportedSubscriptions(Uri uri) {
 		try {
 			final List<ImportSubscriptionsChannel> channels = new ArrayList<>();
@@ -382,6 +390,10 @@ public class SubscriptionsBackupsManager {
 		}
 	}
 
+	/**
+	 * AsyncTask to loop through a list of channels to subscribe to. A Dialog will appear notifying the user of the progress
+	 * of fetching videos for each channel.
+	 */
 	private class SubscribeToImportedChannelsTask extends AsyncTask<List<ImportSubscriptionsChannel>, Void, Void> {
 		MaterialDialog dialog;
 		private int numChannelsDone = 0;
@@ -430,10 +442,11 @@ public class SubscriptionsBackupsManager {
 					channelsList.add(channelObj);
 					channelObj.init(channel.channelId);
 					SubscriptionsDb.getSubscriptionsDb().subscribe(channelObj);
+					// Need to set this channelObj to subscribed, so that when videos are retrieved for the channel, they get saved into the database.
+					channelObj.setUserSubscribed(true);
 				} catch(IOException e) {
 					e.printStackTrace();
 				}
-
 			}
 			new GetSubscriptionVideosTask(new SubscriptionsFragmentListener() {
 				@Override


### PR DESCRIPTION
…rom newly imported channels. Added comments to SubscriptionsBackupsManager.

This regression was introduced when I moved GetChannelVideosTask into its own file. Previously it had lived inside GetSubscriptionVideosTask, and was always saving the videos it retrieved to the database, since then it was always assumed the channel was subscribed to. But, since GetChannelVideosTask can be called for a channel that is not subscribed to, it should only save the videos it fetched for a channel that it is subscribed to. SubscriptionsBackupsManager will fetch the videos from a channel inside the SubscribeToImportedChannelsTask inner class, but using an array of channels each of which were set to unsubscribed, even though those actual channels had just been subscribed to. The fix was to adjust each channel in this array to have its subscribed state set to true, which allows GetChannelVideosTask to save the videos it fetches into the database.