### PR TITLE
Fixed bug that caused refreshing the Channel Browser to show the next…

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/GetChannelVideos.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/GetChannelVideos.java
@@ -49,6 +49,18 @@ public class GetChannelVideos extends GetYouTubeVideos implements GetChannelVide
 		getChannelVideos.init();
 	}
 
+	/**
+	 * Since this GetYouTubeVideos class uses its own instance of GetYouTubeVideos (getChannelVideos),
+	 * when reset() is called on this instance, it must call reset on getChannelVideos. Otherwise,
+	 * when a refresh is called via the Channel Browser, the next page of videos will be shown, instead
+	 * of the first page.
+	 */
+	@Override
+	public void reset() {
+		super.reset();
+		getChannelVideos.reset();
+	}
+
 	@Override
 	public List<YouTubeVideo> getNextVideos() {
 		return getChannelVideos.getNextVideos();


### PR DESCRIPTION
… page of videos, instead of the first.

To see this bug in action, simple swipe down to refresh while in the Channel Browser. You'll note that the video grid gets populated with the next page of videos, instead of the first. If you keep refreshing, it will keep showing the next page of videos, after clearing the list.

This is due to the fact that the instance of GetYouTubeVideos that ChannelBrowserFragment uses uses its own instance of GetYouTubeVideos, which itself needs to be reset when a refresh is called.