### PR TITLE
Ignore MissingTranslation

### DIFF
--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 	<string name="preferences">Preferences</string>
 
 	<string name="pref_languages_category">Languages &amp; Regions</string>


### PR DESCRIPTION
This should fix the warning in https://github.com/ram-on/SkyTube/pull/165 .
Another approach is to move all non translatable strings to donottranslate.xml