### PR TITLE
MainFragment should save the state of its Child Fragments, when the A…

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -50,6 +50,7 @@ public class MainFragment extends FragmentEx {
 	public static final String MOST_POPULAR_VIDEOS_FRAGMENT = "MainFragment.mostPopularVideosFragment";
 	public static final String SUBSCRIPTIONS_FEED_FRAGMENT = "MainFragment.subscriptionsFeedFragment";
 	public static final String BOOKMARKS_FRAGMENT = "MainFragment.bookmarksFragment";
+	public static final String DOWNLOADED_VIDEOS_FRAGMENT = "MainFragment.downloadedVideosFragment";
 
 	private VideosPagerAdapter			videosPagerAdapter = null;
 	private ViewPager					viewPager;
@@ -66,6 +67,7 @@ public class MainFragment extends FragmentEx {
 			mostPopularVideosFragment = (MostPopularVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, MOST_POPULAR_VIDEOS_FRAGMENT);
 			subscriptionsFeedFragment = (SubscriptionsFeedFragment)getChildFragmentManager().getFragment(savedInstanceState, SUBSCRIPTIONS_FEED_FRAGMENT);
 			bookmarksFragment = (BookmarksFragment) getChildFragmentManager().getFragment(savedInstanceState, BOOKMARKS_FRAGMENT);
+			downloadedVideosFragment = (DownloadedVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, DOWNLOADED_VIDEOS_FRAGMENT);
 		}
 	}
 
@@ -232,6 +234,8 @@ public class MainFragment extends FragmentEx {
 			getChildFragmentManager().putFragment(outState, SUBSCRIPTIONS_FEED_FRAGMENT, subscriptionsFeedFragment);
 		if(bookmarksFragment != null)
 			getChildFragmentManager().putFragment(outState, BOOKMARKS_FRAGMENT, bookmarksFragment);
+		if(downloadedVideosFragment != null)
+			getChildFragmentManager().putFragment(outState, DOWNLOADED_VIDEOS_FRAGMENT, downloadedVideosFragment);
 
 		super.onSaveInstanceState(outState);
 	}

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -110,7 +110,7 @@ public class MainFragment extends FragmentEx {
 
 		videosPagerAdapter = new VideosPagerAdapter(getChildFragmentManager());
 		viewPager = view.findViewById(R.id.pager);
-		viewPager.setOffscreenPageLimit(3);
+		viewPager.setOffscreenPageLimit(videoGridFragmentsList.size() - 1);
 		viewPager.setAdapter(videosPagerAdapter);
 
 		TabLayout tabLayout = view.findViewById(R.id.tab_layout);

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -45,11 +45,29 @@ public class MainFragment extends FragmentEx {
 	private BookmarksFragment			bookmarksFragment = null;
 	private DownloadedVideosFragment downloadedVideosFragment = null;
 
+	// Constants for saving the state of this Fragment's child Fragments
+	public static final String FEATURED_VIDEOS_FRAGMENT = "MainFragment.featuredVideosFragment";
+	public static final String MOST_POPULAR_VIDEOS_FRAGMENT = "MainFragment.mostPopularVideosFragment";
+	public static final String SUBSCRIPTIONS_FEED_FRAGMENT = "MainFragment.subscriptionsFeedFragment";
+	public static final String BOOKMARKS_FRAGMENT = "MainFragment.bookmarksFragment";
+
 	private VideosPagerAdapter			videosPagerAdapter = null;
 	private ViewPager					viewPager;
 
 	public static final String SHOULD_SELECTED_FEED_TAB = "MainFragment.SHOULD_SELECTED_FEED_TAB";
 
+
+	@Override
+	public void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		if(savedInstanceState != null) {
+			featuredVideosFragment = (FeaturedVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, FEATURED_VIDEOS_FRAGMENT);
+			mostPopularVideosFragment = (MostPopularVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, MOST_POPULAR_VIDEOS_FRAGMENT);
+			subscriptionsFeedFragment = (SubscriptionsFeedFragment)getChildFragmentManager().getFragment(savedInstanceState, SUBSCRIPTIONS_FEED_FRAGMENT);
+			bookmarksFragment = (BookmarksFragment) getChildFragmentManager().getFragment(savedInstanceState, BOOKMARKS_FRAGMENT);
+		}
+	}
 
 	@Nullable
 	@Override
@@ -204,4 +222,17 @@ public class MainFragment extends FragmentEx {
 
 	}
 
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		if(featuredVideosFragment != null)
+			getChildFragmentManager().putFragment(outState, FEATURED_VIDEOS_FRAGMENT, featuredVideosFragment);
+		if(mostPopularVideosFragment != null)
+			getChildFragmentManager().putFragment(outState, MOST_POPULAR_VIDEOS_FRAGMENT, mostPopularVideosFragment);
+		if(subscriptionsFeedFragment != null)
+			getChildFragmentManager().putFragment(outState, SUBSCRIPTIONS_FEED_FRAGMENT, subscriptionsFeedFragment);
+		if(bookmarksFragment != null)
+			getChildFragmentManager().putFragment(outState, BOOKMARKS_FRAGMENT, bookmarksFragment);
+
+		super.onSaveInstanceState(outState);
+	}
 }


### PR DESCRIPTION
…ctivity needs to be destroyed, and restore them when it's recreated. Not doing this was causing the child fragments to be recreated, and for the currently selected one to be set not selected, which was preventing the Refresh Dialog from showing when the default fragment was the Subscriptions Feed Fragment.

@ram-on It turns out that fix I implemented awhile back (https://github.com/ram-on/SkyTube/pull/169/commits/769bcd45dfbc4727880c6484a9d92c8dcf3d1483#diff-53cf7c2eb7dea2c5d7afeb3fb6c0b648R114) was incomplete. I'm not sure how I missed it. I figured out what the problem was by adding a bunch of logging, and when the activity gets recreated (again by going to Settings->Developer Options->Don't Keep Activities), I noticed that when I would log the `subscriptionsFeedFragment` instance in MainFragment, its identityHashCode was different from when I'd log `this` from within `SubscriptionsFeedFragment`. So, they weren't the actual same instance in memory (and `SubscriptionsFeedFragment` wasn't set as selected). 

To illustrate this, I created a branch (which doesn't have the fix this PR has) that adds the Logging I had done: https://github.com/atomjack/SkyTube/tree/feed-refresh-fix-new-logs. Another change that branch has is that instead of only refreshing every 3 hours, it refreshes every 10 seconds. Here's some steps you can take to see the problem (with the `feed-refresh-fix-new-logs` branch):

1. Set the option to not keep activities.
2. Fire up the app, wait for it to finish its initial refresh, make sure the Feed tab is set to be default (and selected), then go back to your home screen.
3. In Android Studio, filter the logcat output by "refresh" (all of the log lines I added have this word in them).
4. Wait at least 10 seconds, and then fire up the app again, which causes the activity to get recreated. 

If you look at the logcat lines, you'll notice the line that's being outputted from `SubscriptionsFeedFragment.GetTotalNumberOfChannelsTask`, as well as one from MainFragment:
```
12-18 13:27:04.704 5218-5218/free.rm.skytube.oss D/MainFragment: refresh stuff, setting current tab as selected: SubscriptionsFeedFragment{3661c5a}
12-18 13:27:04.892 5218-5218/free.rm.skytube.oss D/GetTotalNumberOfChannelsTask: Should refresh true, is fragment selected? false, this: SubscriptionsFeedFragment{5f65c44 #0 id=0x7f0900b8 android:switcher:2131296440:2}
```

You'll see that the identity hash code of `SubscriptionsFeedFragment` in `MainFragment` is `3661c5a`, yet inside `SubscriptionsFeedFragment.GetTotalNumberOfChannelsTask`, its `5f65c44`, and that instance of `SubscriptionsFeedFragment` wasn't set as selected. Once I implemented the change in this PR, of saving MainFragment's child fragments, the identity hash codes matched up, and the refresh dialog appeared as expected (because `subscriptionsFeedFragment` was set as selected).

You can ignore the `feed-refresh-fix-new-logs` branch after that, but if you try out this branch (`feed-refresh-fix-new`), edit line 79 of `SubscriptionsFeedFragment, and set it to look at a smaller time, like 10 seconds ago (`new DateTime().minusSeconds(10)`), and if you try the above steps again (ignoring the logcat parts), you'll see the refresh dialog show, as expected.
