### PR TITLE
Spelling: Mobile networks, Wi-Fi

### DIFF
--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -486,8 +486,8 @@
 	<string name="pref_youtube_api_key_default">Restart app to switch back to default YouTube API key.</string>
 
 	<string name="pref_key_allow_mobile_downloads">pref_allow_mobile_downloads_key</string>
-	<string name="pref_title_allow_mobile_downloads">Allow downloads on Mobile Networks</string>
-	<string name="pref_summary_allow_mobile_downloads">If checked, videos can be downloaded on Mobile networks. Otherwise, videos can only be downloaded on WiFi.</string>
+	<string name="pref_title_allow_mobile_downloads">Allow downloads on mobile networks</string>
+	<string name="pref_summary_allow_mobile_downloads">Select this to enable downloading videos on mobile networks. Otherwise, videos can only be downloaded on Wi-Fi.</string>
 
 	<string name="restart">Restart</string>
 </resources>


### PR DESCRIPTION
The alternative is "cellular networks".