### PR TITLE
Spelling: Channel information, - found

### DIFF
--- a/app/src/main/res/values/strings_feed.xml
+++ b/app/src/main/res/values/strings_feed.xml
@@ -3,8 +3,8 @@
 	<string name="feed">Feed</string>
 
 	<string name="subscribing_to_channels">Subscribing to channels…</string>
-	<string name="fetching_subbed_channels_info">Fetching channels\'s information…</string>
-	<string name="fetching_subbed_channels_info_error">An error has occurred while fetching channels\'s information.</string>
+	<string name="fetching_subbed_channels_info">Fetching channel information…</string>
+	<string name="fetching_subbed_channels_info_error">An error has occurred while fetching channel information.</string>
 
 	<string name="fetching_subscription_videos">Fetching videos from subscribed channels</string>
 	<string name="fetched_videos_from_channels">Fetched %1$d videos from %2$d/%3$d channels.</string>
@@ -12,5 +12,5 @@
 	<string name="no_subscriptions_text">You aren\'t subscribed to any channels.\n\nOnce you are, all videos uploaded to your subscribed channels within the last month will appear here.</string>
 	<string name="import_subscriptions_from_youtube">Import Subscriptions From YouTube</string>
 	<string name="notification_channel_feed_title">Feed Notifications</string>
-	<string name="notification_new_videos_found">%d new videos from subscribed channels found</string>
+	<string name="notification_new_videos_found">%d new videos from subscribed channels</string>
 </resources>

--- a/app/src/main/res/values/strings_feed.xml
+++ b/app/src/main/res/values/strings_feed.xml
@@ -3,8 +3,8 @@
 	<string name="feed">Feed</string>
 
 	<string name="subscribing_to_channels">Subscribing to channels…</string>
-	<string name="fetching_subbed_channels_info">Fetching channel information…</string>
-	<string name="fetching_subbed_channels_info_error">An error has occurred while fetching channel information.</string>
+	<string name="fetching_subbed_channels_info">Fetching channels\' information…</string>
+	<string name="fetching_subbed_channels_info_error">An error has occurred while fetching channels\' information.</string>
 
 	<string name="fetching_subscription_videos">Fetching videos from subscribed channels</string>
 	<string name="fetched_videos_from_channels">Fetched %1$d videos from %2$d/%3$d channels.</string>


### PR DESCRIPTION
Like "map info"
Alternatively, "information about channels"
Found was just redundant