### PR TITLE
Intercept links to youtube videos and playlists to open them in the app.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:core:0.9.5.0'
     implementation 'com.github.angads25:filepicker:1.1.1'
     implementation 'com.google.android.exoplayer:exoplayer:2.7.0'
+    implementation 'com.klinkerapps:link_builder:1.6.1'
 
     // Android support modules
     implementation 'com.android.support:appcompat-v7:27.1.0'

--- a/app/src/main/java/free/rm/skytube/app/SkyTubeApp.java
+++ b/app/src/main/java/free/rm/skytube/app/SkyTubeApp.java
@@ -22,24 +22,42 @@ import android.app.AlarmManager;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.multidex.MultiDexApplication;
-import android.support.v4.content.IntentCompat;
+import android.support.v7.app.AlertDialog;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.klinker.android.link_builder.Link;
+import com.klinker.android.link_builder.LinkBuilder;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import free.rm.skytube.R;
 import free.rm.skytube.businessobjects.FeedUpdaterReceiver;
+import free.rm.skytube.businessobjects.GetPlaylistTask;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
+import free.rm.skytube.gui.activities.MainActivity;
+import free.rm.skytube.gui.businessobjects.PlaylistClickListener;
+import free.rm.skytube.gui.businessobjects.YouTubePlayer;
+import free.rm.skytube.gui.businessobjects.YouTubePlaylistListener;
+import free.rm.skytube.gui.fragments.PlaylistVideosFragment;
 
 /**
  * SkyTube application.
@@ -209,6 +227,94 @@ public class SkyTubeApp extends MultiDexApplication {
 		if(interval > 0) {
 			alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime()+interval, interval, pendingIntent);
 		}
+	}
+
+	/**
+	 * Linkify the text inside the passed TextView, but intercept certain kinds of urls, to instead open them
+	 * from within the app itself (i.e. YouTube video urls, playlist urls, etc). Also, capture all long clicks
+	 * to show a menu to open, copy, or share the url.
+	 * @param context The Activity context (this is needed instead of getContext(), in order to display the long click menu.
+	 * @param textView The TextView whose contents will be modified
+	 * @param youTubePlaylistListener	A Listener to handle a clicked link to a YouTube Playlist
+	 */
+	public static void interceptYouTubeLinks(final Context context, TextView textView, final YouTubePlaylistListener youTubePlaylistListener) {
+		Link link = new Link(android.util.Patterns.WEB_URL);
+		final Pattern videoPattern = Pattern.compile("http(?:s?):\\/\\/(?:www\\.)?youtu(?:be\\.com\\/watch\\?v=|\\.be\\/)([\\w\\-\\_]*)(&(amp;)?\u200C\u200B[\\w\\?\u200C\u200B=]*)?");
+		final Pattern playlistPattern = Pattern.compile("^.*(youtu.be\\/|list=)([^#\\&\\?]*).*");
+		link.setOnClickListener(new Link.OnClickListener() {
+			@Override
+			public void onClick(String clickedText) {
+				final Matcher playlistMatcher = playlistPattern.matcher(clickedText);
+				if(videoPattern.matcher(clickedText).matches()) {
+					YouTubePlayer.launch(clickedText, context);
+				} else if(playlistMatcher.find()) {
+					String playlistId = playlistMatcher.group(2);
+					// Retrieve the playlist from the playlist ID that was in the url the user clicked on
+					new GetPlaylistTask(playlistId, new PlaylistClickListener() {
+						@Override
+						public void onClickPlaylist(YouTubePlaylist playlist) {
+							if (youTubePlaylistListener != null) {
+								youTubePlaylistListener.onYouTubePlaylist(playlist);
+							} else {
+								// Pass the clicked playlist to PlaylistVideosFragment.
+								Intent playlistIntent = new Intent(context, MainActivity.class);
+								playlistIntent.setAction(MainActivity.ACTION_VIEW_PLAYLIST);
+								playlistIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+								playlistIntent.putExtra(PlaylistVideosFragment.PLAYLIST_OBJ, playlist);
+								context.startActivity(playlistIntent);
+							}
+						}
+					}).executeInParallel();
+				} else {
+					Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(clickedText));
+					browserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+					context.startActivity(browserIntent);
+				}
+			}
+		});
+
+		// Handle long click by showing a dialog allowing the user to open the link in a browser, copy the url, or share it.
+		link.setOnLongClickListener(new Link.OnLongClickListener() {
+			@Override
+			public void onLongClick(final String clickedText) {
+				AlertDialog.Builder builder = new AlertDialog.Builder(context)
+								.setTitle(clickedText)
+								.setItems(new CharSequence[]
+										{getStr(R.string.open_in_browser), getStr(R.string.copy_url), getStr(R.string.share_via)},
+										new DialogInterface.OnClickListener() {
+											@Override
+											public void onClick(DialogInterface dialog, int which) {
+												switch (which) {
+													case 0:
+														Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(clickedText));
+														browserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+														context.startActivity(browserIntent);
+														break;
+													case 1:
+														ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+														ClipData clip = ClipData.newPlainText("URL", clickedText);
+														clipboard.setPrimaryClip(clip);
+														Toast.makeText(context, R.string.url_copied_to_clipboard, Toast.LENGTH_SHORT).show();
+														break;
+													case 2:
+														Intent intent = new Intent(android.content.Intent.ACTION_SEND);
+														intent.setType("text/plain");
+														intent.putExtra(android.content.Intent.EXTRA_TEXT, clickedText);
+														context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_via)));
+														break;
+												}
+											}
+										});
+								builder.create().show();
+			}
+		});
+		LinkBuilder.on(textView)
+			.addLink(link)
+			.build();
+	}
+
+	public static void interceptYouTubeLinks(Context context, TextView textView) {
+		interceptYouTubeLinks(context, textView, null);
 	}
 
 }

--- a/app/src/main/java/free/rm/skytube/app/SkyTubeApp.java
+++ b/app/src/main/java/free/rm/skytube/app/SkyTubeApp.java
@@ -243,7 +243,7 @@ public class SkyTubeApp extends MultiDexApplication {
 	 */
 	public static void interceptYouTubeLinks(final Context context, TextView textView, final YouTubePlaylistListener youTubePlaylistListener) {
 		Link link = new Link(android.util.Patterns.WEB_URL);
-		final Pattern videoPattern = Pattern.compile("http(?:s?):\\/\\/(?:www\\.)?youtu(?:be\\.com\\/watch\\?v=|\\.be\\/)([\\w\\-\\_]*)(&(amp;)?\u200C\u200B[\\w\\?\u200C\u200B=]*)?");
+		final Pattern videoPattern = Pattern.compile("http(?:s?):\\/\\/(?:www\\.)?youtu(?:be\\.com\\/watch\\?v=|\\.be\\/)([\\w\\-\\_]*)(&(amp;)?[\\w\\?=\\.]*)?");
 		final Pattern playlistPattern = Pattern.compile("^.*(youtu.be\\/|list=)([^#\\&\\?]*).*");
 		final Pattern channelPattern = Pattern.compile("(?:https|http)\\:\\/\\/(?:[\\w]+\\.)?youtube\\.com\\/(?:c\\/|channel\\/|user\\/)?([a-zA-Z0-9\\-]{1,})");
 		link.setOnClickListener(new Link.OnClickListener() {
@@ -253,7 +253,7 @@ public class SkyTubeApp extends MultiDexApplication {
 				final Matcher channelMatcher = channelPattern.matcher(clickedText);
 				if(videoPattern.matcher(clickedText).matches()) {
 					YouTubePlayer.launch(clickedText, context);
-				} else if(playlistMatcher.find()) {
+				} else if(playlistMatcher.matches()) {
 					String playlistId = playlistMatcher.group(2);
 					// Retrieve the playlist from the playlist ID that was in the url the user clicked on
 					new GetPlaylistTask(playlistId, new PlaylistClickListener() {
@@ -270,7 +270,7 @@ public class SkyTubeApp extends MultiDexApplication {
 							}
 						}
 					}).executeInParallel();
-				} else if(channelMatcher.find()) {
+				} else if(channelMatcher.matches()) {
 					String username = channelMatcher.group(1);
 					new GetYouTubeChannelInfoTask(getContext(), new YouTubeChannelInterface() {
 						@Override

--- a/app/src/main/java/free/rm/skytube/businessobjects/GetPlaylist.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/GetPlaylist.java
@@ -1,0 +1,97 @@
+package free.rm.skytube.businessobjects;
+
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.Playlist;
+import com.google.api.services.youtube.model.PlaylistListResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import free.rm.skytube.businessobjects.YouTube.GetChannelsDetails;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeAPI;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeAPIKey;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
+
+/**
+ * Returns a YouTubePlaylist for the specified Playlist URL.
+ *
+ * <p>Do not run this directly, but rather use {@link GetPlaylistTask}.</p>
+ */
+public class GetPlaylist {
+	protected YouTube.Playlists.List playlistList = null;
+
+	protected static final Long	MAX_RESULTS = 45L;
+
+	protected String nextPageToken = null;
+	protected boolean noMorePlaylistPages = false;
+
+	public void init(String playlistId) throws IOException {
+		playlistList = YouTubeAPI.create().playlists().list("id, snippet, contentDetails");
+		playlistList.setKey(YouTubeAPIKey.get().getYouTubeAPIKey());
+		playlistList.setFields("items(id, snippet/title, snippet/description, snippet/thumbnails, snippet/publishedAt, contentDetails/itemCount, snippet/channelId)," +
+						"nextPageToken");
+		playlistList.setMaxResults(MAX_RESULTS);
+		playlistList.setId(playlistId);
+
+		nextPageToken = null;
+	}
+
+	public List<YouTubePlaylist> getNextPlaylists() {
+		List<Playlist> playlistList = null;
+
+		if (!noMorePlaylistPages()) {
+			try {
+				// set the page token/id to retrieve
+				this.playlistList.setPageToken(nextPageToken);
+
+				// communicate with YouTube
+				PlaylistListResponse listResponse = this.playlistList.execute();
+
+				// get playlists
+				playlistList = listResponse.getItems();
+
+				// set the next page token
+				nextPageToken = listResponse.getNextPageToken();
+
+				// if nextPageToken is null, it means that there are no more videos
+				if (nextPageToken == null)
+					noMorePlaylistPages = true;
+			} catch (IOException ex) {
+				Logger.d(this, ex.getLocalizedMessage());
+			}
+		}
+
+		return toYouTubePlaylist(playlistList);
+	}
+
+	public boolean noMorePlaylistPages() {
+		return noMorePlaylistPages;
+	}
+
+	protected List<YouTubePlaylist> toYouTubePlaylist(List<Playlist> playlistList) {
+		final List<YouTubePlaylist> youTubePlaylists = new ArrayList<>();
+
+		if(playlistList != null) {
+			for (final Playlist playlist : playlistList) {
+				final YouTubePlaylist youTubePlaylist = new YouTubePlaylist(playlist);
+				// YouTubePlaylist object is now available, but we need to set its channel. We only have the channel ID, so init a new
+				// YouTubeChannel object with the id, and set the playlist's channel
+				YouTubeChannel channel;
+				try {
+					channel = new GetChannelsDetails().getYouTubeChannel(youTubePlaylist.getChannelId());
+					if (channel != null) {
+						youTubePlaylist.setChannel(channel);
+					}
+				} catch (IOException e) {
+					Logger.d(this, "Unable to get channel info: %s", youTubePlaylist.getChannelId());
+				}
+
+
+				youTubePlaylists.add(youTubePlaylist);
+			}
+		}
+		return youTubePlaylists;
+	}
+}

--- a/app/src/main/java/free/rm/skytube/businessobjects/GetPlaylistTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/GetPlaylistTask.java
@@ -1,0 +1,39 @@
+package free.rm.skytube.businessobjects;
+
+import java.io.IOException;
+
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
+import free.rm.skytube.gui.businessobjects.PlaylistClickListener;
+
+/**
+ * An asynchronous task that will retrieve a YouTube playlist for a specified playlist URL.
+ */
+public class GetPlaylistTask extends AsyncTaskParallel<Void, Void, YouTubePlaylist> {
+	private String playlistId;
+	private PlaylistClickListener playlistClickListener;
+	private GetPlaylist getPlaylist;
+
+	public GetPlaylistTask(String playlistId, PlaylistClickListener playlistClickListener) {
+		this.playlistId = playlistId;
+		this.playlistClickListener = playlistClickListener;
+	}
+
+	@Override
+	protected YouTubePlaylist doInBackground(Void... voids) {
+		try {
+			getPlaylist = new GetPlaylist();
+			getPlaylist.init(playlistId);
+			return getPlaylist.getNextPlaylists().get(0);
+		} catch (IOException e) {
+			Logger.e(this, "Couldn't initialize GetPlaylist");
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	@Override
+	protected void onPostExecute(YouTubePlaylist youTubePlaylist) {
+		if(playlistClickListener != null)
+			playlistClickListener.onClickPlaylist(youTubePlaylist);
+	}
+}

--- a/app/src/main/java/free/rm/skytube/businessobjects/GetVideoDetailsTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/GetVideoDetailsTask.java
@@ -1,0 +1,70 @@
+package free.rm.skytube.businessobjects;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.List;
+
+import free.rm.skytube.businessobjects.YouTube.GetVideosDetailsByIDs;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
+import free.rm.skytube.gui.businessobjects.YouTubeVideoListener;
+
+/**
+ * An asynchronous task that will, from the given video URL, get the details of the video (e.g. video name,
+ * likes ...etc).
+ */
+public class GetVideoDetailsTask extends AsyncTaskParallel<Void, Void, YouTubeVideo> {
+
+	private String videoUrl = null;
+	private YouTubeVideoListener youTubeVideoListener;
+
+	public GetVideoDetailsTask(String videoUrl, YouTubeVideoListener youTubeVideoListener) {
+		this.videoUrl = videoUrl;
+		this.youTubeVideoListener = youTubeVideoListener;
+	}
+
+	@Override
+	protected void onPreExecute() {
+		try {
+			// YouTube sends subscriptions updates email in which its videos' URL are encoded...
+			// Hence we need to decode them first...
+			videoUrl = URLDecoder.decode(videoUrl, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			Logger.e(this, "UnsupportedEncodingException on " + videoUrl + " encoding = UTF-8", e);
+		}
+	}
+
+
+	/**
+	 * Returns an instance of {@link YouTubeVideo} from the given {@link #videoUrl}.
+	 *
+	 * @return {@link YouTubeVideo}; null if an error has occurred.
+	 */
+	@Override
+	protected YouTubeVideo doInBackground(Void... params) {
+		String videoId = YouTubeVideo.getYouTubeIdFromUrl(videoUrl);
+		YouTubeVideo youTubeVideo = null;
+
+		if (videoId != null) {
+			try {
+				GetVideosDetailsByIDs getVideo = new GetVideosDetailsByIDs();
+				getVideo.init(videoId);
+				List<YouTubeVideo> youTubeVideos = getVideo.getNextVideos();
+
+				if (youTubeVideos.size() > 0)
+					youTubeVideo = youTubeVideos.get(0);
+			} catch (IOException ex) {
+				Logger.e(this, "Unable to get video details, where id=" + videoId, ex);
+			}
+		}
+
+		return youTubeVideo;
+	}
+
+
+	@Override
+	protected void onPostExecute(YouTubeVideo youTubeVideo) {
+		if(youTubeVideoListener != null)
+			youTubeVideoListener.onYouTubeVideo(videoUrl, youTubeVideo);
+	}
+}

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/GetChannelsDetails.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/GetChannelsDetails.java
@@ -101,6 +101,40 @@ public class GetChannelsDetails {
 		return (channelList != null  &&  channelList.size() > 0)  ?  channelList.get(0)  :  null;
 	}
 
+	/**
+	 * Return a YouTubeChannel object from the passed username.
+	 *
+	 * This should not be called from the main thread.
+	 *
+	 * @param username	The YouTube username
+	 *
+	 * @return	YouTubeChannel
+	 */
+	public YouTubeChannel getYouTubeChannelFromUsername(String username) throws IOException {
+
+		String  bannerType = SkyTubeApp.isTablet() ? "bannerTabletHdImageUrl" : "bannerMobileHdImageUrl";
+
+		YouTube youtube = YouTubeAPI.create();
+		YouTube.Channels.List channelInfo = youtube.channels().list("snippet, statistics, brandingSettings");
+
+		channelInfo.setForUsername(username);
+		channelInfo.setFields("items(id, snippet/title, snippet/description, snippet/thumbnails/default," +
+						"statistics/subscriberCount, brandingSettings/image/" + bannerType + ")," +
+						"nextPageToken")
+						.setKey(YouTubeAPIKey.get().getYouTubeAPIKey());
+
+		ChannelListResponse response = channelInfo.execute();
+		List<Channel> channelList = response.getItems();
+
+		if(channelList != null && channelList.size() > 0) {
+			YouTubeChannel youTubeChannel = new YouTubeChannel();
+			youTubeChannel.init(channelList.get(0), false, false);
+			return youTubeChannel;
+		}
+
+		return null;
+	}
+
 
 	/**
 	 * Divides the given list into a list of lists in which each list is made up of no more than

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubePlaylist.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubePlaylist.java
@@ -40,6 +40,11 @@ public class YouTubePlaylist implements Serializable {
 
 	/** The YouTube Channel object that this playlist belongs to. */
 	private YouTubeChannel channel;
+	private String channelId;
+
+	public YouTubePlaylist(Playlist playlist) {
+		this(playlist, null);
+	}
 
 	public YouTubePlaylist(Playlist playlist, YouTubeChannel channel) {
 		id = playlist.getId();
@@ -49,6 +54,7 @@ public class YouTubePlaylist implements Serializable {
 			title = playlist.getSnippet().getTitle();
 			description = playlist.getSnippet().getDescription();
 			publishDate = playlist.getSnippet().getPublishedAt();
+			channelId = playlist.getSnippet().getChannelId();
 
 			if(playlist.getSnippet().getThumbnails() != null) {
 				Thumbnail thumbnail = playlist.getSnippet().getThumbnails().getHigh();
@@ -92,6 +98,14 @@ public class YouTubePlaylist implements Serializable {
 
 	public YouTubeChannel getChannel() {
 		return channel;
+	}
+
+	public void setChannel(YouTubeChannel channel) {
+		this.channel = channel;
+	}
+
+	public String getChannelId() {
+		return channelId;
 	}
 
 	/**

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeChannelInfoTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeChannelInfoTask.java
@@ -24,10 +24,10 @@ import java.io.IOException;
 
 import free.rm.skytube.R;
 import free.rm.skytube.businessobjects.AsyncTaskParallel;
+import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.GetChannelsDetails;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannelInterface;
-import free.rm.skytube.businessobjects.Logger;
 
 /**
  * A task that given a channel ID it will try to initialize and return {@link YouTubeChannel}.
@@ -36,10 +36,20 @@ public class GetYouTubeChannelInfoTask extends AsyncTaskParallel<String, Void, Y
 
 	private YouTubeChannelInterface youTubeChannelInterface;
 	private Context context;
+	private boolean usingUsername = false;
 
 	public GetYouTubeChannelInfoTask(Context context, YouTubeChannelInterface youTubeChannelInterface) {
 		this.context = context;
 		this.youTubeChannelInterface = youTubeChannelInterface;
+	}
+
+	/**
+	 * Set the flag that the execution of this task is passing a username, not an id.
+	 * @return this object, for chaining
+	 */
+	public GetYouTubeChannelInfoTask setUsingUsername() {
+		usingUsername = true;
+		return this;
 	}
 
 
@@ -48,7 +58,10 @@ public class GetYouTubeChannelInfoTask extends AsyncTaskParallel<String, Void, Y
 		YouTubeChannel channel;
 
 		try {
-			channel = new GetChannelsDetails().getYouTubeChannel(channelId[0]);
+			if(usingUsername)
+				channel = new GetChannelsDetails().getYouTubeChannelFromUsername(channelId[0]);
+			else
+				channel = new GetChannelsDetails().getYouTubeChannel(channelId[0]);
 		} catch (IOException e) {
 			Logger.e(this, "Unable to get channel info.  ChannelID=" + channelId[0], e);
 			channel = null;

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -40,7 +40,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
-import free.rm.skytube.gui.businessobjects.adapters.SearchHistoryCursorAdapter;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
 import free.rm.skytube.businessobjects.db.DownloadedVideosDb;
@@ -49,6 +48,7 @@ import free.rm.skytube.businessobjects.db.SearchHistoryTable;
 import free.rm.skytube.businessobjects.interfaces.SearchHistoryClickListener;
 import free.rm.skytube.gui.businessobjects.MainActivityListener;
 import free.rm.skytube.gui.businessobjects.YouTubePlayer;
+import free.rm.skytube.gui.businessobjects.adapters.SearchHistoryCursorAdapter;
 import free.rm.skytube.gui.businessobjects.updates.UpdatesCheckerTask;
 import free.rm.skytube.gui.fragments.ChannelBrowserFragment;
 import free.rm.skytube.gui.fragments.MainFragment;
@@ -76,6 +76,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityListe
 
 	public static final String ACTION_VIEW_CHANNEL = "MainActivity.ViewChannel";
 	public static final String ACTION_VIEW_FEED = "MainActivity.ViewFeed";
+	public static final String ACTION_VIEW_PLAYLIST = "MainActivity.ViewPlaylist";
 	private static final String MAIN_FRAGMENT   = "MainActivity.MainFragment";
 	private static final String SEARCH_FRAGMENT = "MainActivity.SearchFragment";
 	public static final String CHANNEL_BROWSER_FRAGMENT = "MainActivity.ChannelBrowserFragment";
@@ -115,6 +116,15 @@ public class MainActivity extends AppCompatActivity implements MainActivityListe
 				dontAddToBackStack = true;
 				YouTubeChannel channel = (YouTubeChannel) getIntent().getSerializableExtra(ChannelBrowserFragment.CHANNEL_OBJ);
 				onChannelClick(channel);
+			} else if(ACTION_VIEW_PLAYLIST.equals(action)) {
+				// Set up the MainFragment, if needed, and add it to the backstack, so that when the user exits from the playlist whose url they just
+				// clicked on, they return to the Main Screen of the app.
+				if(mainFragment == null) {
+					mainFragment = new MainFragment();
+					getSupportFragmentManager().beginTransaction().add(R.id.fragment_container, mainFragment).commit();
+				}
+				YouTubePlaylist playlist = (YouTubePlaylist)getIntent().getSerializableExtra(PlaylistVideosFragment.PLAYLIST_OBJ);
+				onPlaylistClick(playlist);
 			} else {
 				if(mainFragment == null) {
 					mainFragment = new MainFragment();

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -117,12 +117,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityListe
 				YouTubeChannel channel = (YouTubeChannel) getIntent().getSerializableExtra(ChannelBrowserFragment.CHANNEL_OBJ);
 				onChannelClick(channel);
 			} else if(ACTION_VIEW_PLAYLIST.equals(action)) {
-				// Set up the MainFragment, if needed, and add it to the backstack, so that when the user exits from the playlist whose url they just
-				// clicked on, they return to the Main Screen of the app.
-				if(mainFragment == null) {
-					mainFragment = new MainFragment();
-					getSupportFragmentManager().beginTransaction().add(R.id.fragment_container, mainFragment).commit();
-				}
+				dontAddToBackStack = true;
 				YouTubePlaylist playlist = (YouTubePlaylist)getIntent().getSerializableExtra(PlaylistVideosFragment.PLAYLIST_OBJ);
 				onPlaylistClick(playlist);
 			} else {

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YouTubePlaylistListener.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YouTubePlaylistListener.java
@@ -1,0 +1,12 @@
+package free.rm.skytube.gui.businessobjects;
+
+
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
+
+/**
+ * An interface to return a YouTube Playlist
+ */
+public interface YouTubePlaylistListener {
+	void onYouTubePlaylist(YouTubePlaylist playlist);
+
+}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YouTubeVideoListener.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YouTubeVideoListener.java
@@ -1,0 +1,11 @@
+package free.rm.skytube.gui.businessobjects;
+
+
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
+
+/**
+ * Interface to return a YouTubeVideo via an url to the video. Returns the url as well as the video, if one was found.
+ */
+public interface YouTubeVideoListener {
+	void onYouTubeVideo(String videoUrl, YouTubeVideo video);
+}

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerFragment.java
@@ -33,33 +33,29 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.List;
 import java.util.Locale;
 
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
-import free.rm.skytube.businessobjects.AsyncTaskParallel;
-import free.rm.skytube.businessobjects.YouTube.Tasks.GetVideoDescriptionTask;
-import free.rm.skytube.businessobjects.YouTube.GetVideosDetailsByIDs;
-import free.rm.skytube.businessobjects.YouTube.Tasks.GetYouTubeChannelInfoTask;
-import free.rm.skytube.businessobjects.YouTube.VideoStream.StreamMetaData;
+import free.rm.skytube.businessobjects.GetVideoDetailsTask;
+import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannelInterface;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
-import free.rm.skytube.businessobjects.db.Tasks.CheckIfUserSubbedToChannelTask;
+import free.rm.skytube.businessobjects.YouTube.Tasks.GetVideoDescriptionTask;
+import free.rm.skytube.businessobjects.YouTube.Tasks.GetYouTubeChannelInfoTask;
+import free.rm.skytube.businessobjects.YouTube.VideoStream.StreamMetaData;
 import free.rm.skytube.businessobjects.db.DownloadedVideosDb;
+import free.rm.skytube.businessobjects.db.Tasks.CheckIfUserSubbedToChannelTask;
+import free.rm.skytube.businessobjects.db.Tasks.IsVideoBookmarkedTask;
 import free.rm.skytube.businessobjects.interfaces.GetDesiredStreamListener;
 import free.rm.skytube.gui.activities.MainActivity;
 import free.rm.skytube.gui.activities.ThumbnailViewerActivity;
-import free.rm.skytube.gui.businessobjects.adapters.CommentsAdapter;
-import free.rm.skytube.businessobjects.db.Tasks.IsVideoBookmarkedTask;
-import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.gui.businessobjects.MediaControllerEx;
 import free.rm.skytube.gui.businessobjects.OnSwipeTouchListener;
 import free.rm.skytube.gui.businessobjects.SubscribeButton;
+import free.rm.skytube.gui.businessobjects.YouTubeVideoListener;
+import free.rm.skytube.gui.businessobjects.adapters.CommentsAdapter;
 import free.rm.skytube.gui.businessobjects.fragments.ImmersiveModeFragment;
 import hollowsoft.slidingdrawer.OnDrawerOpenListener;
 import hollowsoft.slidingdrawer.SlidingDrawer;
@@ -67,7 +63,7 @@ import hollowsoft.slidingdrawer.SlidingDrawer;
 /**
  * A fragment that holds a standalone YouTube player.
  */
-public class YouTubePlayerFragment extends ImmersiveModeFragment implements MediaPlayer.OnPreparedListener {
+public class YouTubePlayerFragment extends ImmersiveModeFragment implements MediaPlayer.OnPreparedListener, YouTubeVideoListener {
 
 	public static final String YOUTUBE_VIDEO_OBJ = "YouTubePlayerFragment.yt_video_obj";
 
@@ -160,7 +156,7 @@ public class YouTubePlayerFragment extends ImmersiveModeFragment implements Medi
 				getVideoInfoTasks();
 			} else {
 				// ... or the video URL is passed to SkyTube via another Android app
-				new GetVideoDetailsTask().executeInParallel();
+				new GetVideoDetailsTask(getUrlFromIntent(getActivity().getIntent()), this).executeInParallel();
 			}
 
 		}
@@ -416,7 +412,7 @@ public class YouTubePlayerFragment extends ImmersiveModeFragment implements Medi
 
 
 	/**
-	 * Will asynchronously retrieve additional video information such as channgel avatar ...etc
+	 * Will asynchronously retrieve additional video information such as channel, avatar ...etc
 	 */
 	private void getVideoInfoTasks() {
 		// get Channel info (e.g. avatar...etc) task
@@ -797,6 +793,7 @@ public class YouTubePlayerFragment extends ImmersiveModeFragment implements Medi
 				@Override
 				public void onFinished(String description) {
 					videoDescriptionTextView.setText(description);
+					SkyTubeApp.interceptYouTubeLinks(getActivity(), videoDescriptionTextView);
 				}
 			}).executeInParallel();
 		} else {
@@ -820,7 +817,6 @@ public class YouTubePlayerFragment extends ImmersiveModeFragment implements Medi
 							.show();
 		}
 	}
-
 
 	/**
 	 * Will check whether the video player tutorial was completed before.  If no, it will return
@@ -868,104 +864,51 @@ public class YouTubePlayerFragment extends ImmersiveModeFragment implements Medi
 
 	////////////////////////////////////////////////////////////////////////////////////////////////
 
-
 	/**
-	 * This task will, from the given video URL, get the details of the video (e.g. video name,
-	 * likes ...etc).
+	 * When a video url is clicked on, attempt to open and play it.
+	 * @param videoUrl
+	 * @param youTubeVideo
 	 */
-	private class GetVideoDetailsTask extends AsyncTaskParallel<Void, Void, YouTubeVideo> {
+	@Override
+	public void onYouTubeVideo(String videoUrl, YouTubeVideo youTubeVideo) {
+		if (youTubeVideo == null) {
+			// invalid URL error (i.e. we are unable to decode the URL)
+			String err = String.format(getString(R.string.error_invalid_url), videoUrl);
+			Toast.makeText(getActivity(), err, Toast.LENGTH_LONG).show();
 
-		private String videoUrl = null;
+			// log error
+			Log.e(TAG, err);
 
+			// close the video player activity
+			closeActivity();
+		} else {
+			YouTubePlayerFragment.this.youTubeVideo = youTubeVideo;
 
-		@Override
-		protected void onPreExecute() {
-			String url = getUrlFromIntent(getActivity().getIntent());
+			// setup the HUD and play the video
+			setUpHUDAndPlayVideo();
 
-			try {
-				// YouTube sends subscriptions updates email in which its videos' URL are encoded...
-				// Hence we need to decode them first...
-				videoUrl = URLDecoder.decode(url, "UTF-8");
-			} catch (UnsupportedEncodingException e) {
-				Log.e(TAG, "UnsupportedEncodingException on " + videoUrl + " encoding = UTF-8", e);
-				videoUrl = url;
-			}
+			getVideoInfoTasks();
+
+			// will now check if the video is bookmarked or not (and then update the menu
+			// accordingly)
+			new IsVideoBookmarkedTask(youTubeVideo, menu).executeInParallel();
 		}
-
-
-		/**
-		 * Returns an instance of {@link YouTubeVideo} from the given {@link #videoUrl}.
-		 *
-		 * @return {@link YouTubeVideo}; null if an error has occurred.
-		 */
-		@Override
-		protected YouTubeVideo doInBackground(Void... params) {
-			String videoId = YouTubeVideo.getYouTubeIdFromUrl(videoUrl);
-			YouTubeVideo youTubeVideo = null;
-
-			if (videoId != null) {
-				try {
-					GetVideosDetailsByIDs getVideo = new GetVideosDetailsByIDs();
-					getVideo.init(videoId);
-					List<YouTubeVideo> youTubeVideos = getVideo.getNextVideos();
-
-					if (youTubeVideos.size() > 0)
-						youTubeVideo = youTubeVideos.get(0);
-				} catch (IOException ex) {
-					Log.e(TAG, "Unable to get video details, where id="+videoId, ex);
-				}
-			}
-
-			return youTubeVideo;
-		}
-
-
-		@Override
-		protected void onPostExecute(YouTubeVideo youTubeVideo) {
-			if (youTubeVideo == null) {
-				// invalid URL error (i.e. we are unable to decode the URL)
-				String err = String.format(getString(R.string.error_invalid_url), videoUrl);
-				Toast.makeText(getActivity(), err, Toast.LENGTH_LONG).show();
-
-				// log error
-				Log.e(TAG, err);
-
-				// close the video player activity
-				closeActivity();
-			} else {
-				YouTubePlayerFragment.this.youTubeVideo = youTubeVideo;
-
-				// setup the HUD and play the video
-				setUpHUDAndPlayVideo();
-
-				getVideoInfoTasks();
-
-				// will now check if the video is bookmarked or not (and then update the menu
-				// accordingly)
-				new IsVideoBookmarkedTask(youTubeVideo, menu).executeInParallel();
-			}
-		}
-
-
-		/**
-		 * The video URL is passed to SkyTube via another Android app (i.e. via an intent).
-		 *
-		 * @return The URL of the YouTube video the user wants to play.
-		 */
-		private String getUrlFromIntent(final Intent intent) {
-			String url = null;
-
-			if (Intent.ACTION_VIEW.equals(intent.getAction()) && intent.getData() != null) {
-				url = intent.getData().toString();
-			}
-
-			return url;
-		}
-
 	}
-
 
 	////////////////////////////////////////////////////////////////////////////////////////////////
 
+	/**
+	 * The video URL is passed to SkyTube via another Android app (i.e. via an intent).
+	 *
+	 * @return The URL of the YouTube video the user wants to play.
+	 */
+	private String getUrlFromIntent(final Intent intent) {
+		String url = null;
 
+		if (Intent.ACTION_VIEW.equals(intent.getAction()) && intent.getData() != null) {
+			url = intent.getData().toString();
+		}
+
+		return url;
+	}
 }

--- a/app/src/main/res/layout/video_description.xml
+++ b/app/src/main/res/layout/video_description.xml
@@ -124,7 +124,7 @@
 			android:text="7 days ago"/>
 
 
-		<TextView
+		<com.klinker.android.link_builder.LinkConsumableTextView
 			android:id="@+id/video_desc_description"
 			android:paddingTop="10dp"
 			android:autoLink="web"


### PR DESCRIPTION
Currently, when clicking on a link (in the video description) to a YouTube Video, or Playlist, it attempts to open the link in the device's browser. This PR instead opens the link in the app itself (if it's a link to a video or playlist). It also captures long clicks on any link, and shows a menu allowing the user to Open the link in the devices browser, copy url, or share.

I chose to put the method that alters the TextView (via the Link Builder library I added to build.gradle) in SkyTubeApp, so that it could be used from anywhere, although it's currently only used from within `YouTubePlayerFragment`.

Also, there's an unused YouTubePlaylistListener interface, but I figured I'd leave it in in case it was ever needed (I could remove it though).

Here are two videos you can test it on:
https://www.youtube.com/watch?v=NmM9HA2MQGI - Has a few links to videos
https://www.youtube.com/watch?v=_GzE99AmAQU - Has a link to a playlist