### PR TITLE
Fixed regression that caused the Feed Refresh dialog to not show agai…

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
@@ -99,14 +99,14 @@ public class SubscriptionsFeedFragment extends VideosGridFragment implements Get
 
 		setLayoutResource(R.layout.fragment_subs_feed);
 		subscriptionsBackupsManager = new SubscriptionsBackupsManager(getActivity(), SubscriptionsFeedFragment.this);
-
-		// setup the UI and refresh the feed (if applicable)
-		new RefreshFeedTask(isFragmentSelected()).executeInParallel();
 	}
 
 
 	@Override
 	public void onResume() {
+		// setup the UI and refresh the feed (if applicable)
+		new RefreshFeedTask(isFragmentSelected()).executeInParallel();
+
 		getActivity().registerReceiver(feedUpdaterReceiver, new IntentFilter(FeedUpdaterService.NEW_SUBSCRIPTION_VIDEOS_FOUND));
 
 		super.onResume();


### PR DESCRIPTION
…n when the app is resume and the Feed tab was selected.

@ram-on, this was a regression due to your recent changes in how the Feed tab refreshes itself. When SubscriptionsFeedFragment.onCreate() is executed, the feed has not yet been set as selected, so when the app resumes, RefreshFeedTask is called but it doesn't yet know that the Feed tab is selected, so it doesn't show the refresh dialog. I've moved the call to that task to onResume(), which gets called after MainFragment has set the Fragment as selected, which results in the Dialog being shown as it should.