### PR TITLE
Force reloading the downloaded files

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
@@ -84,7 +84,7 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 	@Override
 	public void onDownloadedVideosUpdated() {
 		populateList();
-		videoGridAdapter.refresh();
+		videoGridAdapter.refresh(true);
 	}
 
 


### PR DESCRIPTION
... or after a download finished or removed. 
Otherwise the download fragment is not get updated, because GetBookmarksVideos always return null, until a refresh is called