### PR TITLE
Do not throw an NPE during opening the main screen

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeVideosTask.java
@@ -98,9 +98,11 @@ public class GetYouTubeVideosTask extends AsyncTaskParallel<Void, Void, List<You
                 }
                 //filtering system to get the videos that are not blocked
                 //videos are checked by their IDs - if their IDs are blocked they are not loaded.
-                for (YouTubeVideo video : videosList) {
-                    if (!blockedChannelIds.contains(video.getChannelId())) {
-                        youTubeVideoList.add(video);
+                if (videosList != null) {
+                    for (YouTubeVideo video : videosList) {
+                        if (!blockedChannelIds.contains(video.getChannelId())) {
+                            youTubeVideoList.add(video);
+                        }
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
when there is no network available.
In that case the "videosList" is null. 