### PR TITLE
Escape single quotes before searching SearchHistory Database.

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/db/SearchHistoryDb.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/SearchHistoryDb.java
@@ -108,8 +108,8 @@ public class SearchHistoryDb extends SQLiteOpenHelperEx {
 	 */
 	private Cursor getSearchCursor(String searchText, boolean exactTextSearch) {
 		String searchClause = exactTextSearch
-				? String.format(" = '%s'", searchText)
-				: String.format(" LIKE '%s%%'", searchText);
+				? String.format(" = '%s'", searchText.replaceAll("'", "\''"))
+				: String.format(" LIKE '%s%%'", searchText.replaceAll("'", "\''"));
 
 		return getReadableDatabase().query(SearchHistoryTable.TABLE_NAME,
 				new String[] {SearchHistoryTable.COL_SEARCH_ID, SearchHistoryTable.COL_SEARCH_TEXT},


### PR DESCRIPTION
The app was crashing if you used a single quote when searching for videos, because it's searching the SearchHistory database but not escaping the single quote. This PR fixes that.

To reproduce on master, simple start typing the word `it's` into the search box and the app will crash.

I'll note I tried using `DatabaseUtils.sqlEscapeString` but it still crashed.