### PR TITLE
Remove video grid flickering

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetYouTubeVideosTask.java
@@ -45,6 +45,7 @@ public class GetYouTubeVideosTask extends AsyncTaskParallel<Void, Void, List<You
 	private SwipeRefreshLayout  swipeRefreshLayout;
 
 	private YouTubeChannel channel;
+	private boolean clearList;
 
 
 	/**
@@ -53,11 +54,13 @@ public class GetYouTubeVideosTask extends AsyncTaskParallel<Void, Void, List<You
 	 *
 	 * @param getYouTubeVideos The object that does the actual fetching of videos.
 	 * @param videoGridAdapter The grid adapter the videos will be added to.
+	 * @param clearList Clear the list before adding new values to it.
 	 */
-	public GetYouTubeVideosTask(GetYouTubeVideos getYouTubeVideos, VideoGridAdapter videoGridAdapter, SwipeRefreshLayout swipeRefreshLayout) {
+	public GetYouTubeVideosTask(GetYouTubeVideos getYouTubeVideos, VideoGridAdapter videoGridAdapter, SwipeRefreshLayout swipeRefreshLayout, boolean clearList) {
 		this.getYouTubeVideos = getYouTubeVideos;
 		this.videoGridAdapter = videoGridAdapter;
 		this.swipeRefreshLayout = swipeRefreshLayout;
+		this.clearList = clearList;
 	}
 
 
@@ -98,6 +101,9 @@ public class GetYouTubeVideosTask extends AsyncTaskParallel<Void, Void, List<You
 
 	@Override
 	protected void onPostExecute(List<YouTubeVideo> videosList) {
+		if (this.clearList) {
+			videoGridAdapter.clearList();
+		}
 		videoGridAdapter.appendList(videosList);
 
 		if(swipeRefreshLayout != null)

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
@@ -115,8 +115,6 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 		try {
 			Log.i(TAG, videoCategory.toString());
 
-			// clear all previous items in this adapter
-			this.clearList();
 
 			// create a new instance of GetYouTubeVideos
 			this.getYouTubeVideos = videoCategory.createGetYouTubeVideos();
@@ -131,7 +129,7 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 			this.currentVideoCategory = videoCategory;
 
 			// get the videos from the web asynchronously
-			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout).executeInParallel();
+			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout, true).executeInParallel();
 		} catch (IOException e) {
 			Log.e(TAG, "Could not init " + videoCategory, e);
 			Toast.makeText(getContext(),
@@ -179,10 +177,9 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 		if (getYouTubeVideos != null) {
 			if (clearVideosList) {
 				getYouTubeVideos.reset();
-				clearList();
 			}
 
-			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout).executeInParallel();
+			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout, clearVideosList).executeInParallel();
 		}
 	}
 
@@ -197,7 +194,7 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 		if (position >= getItemCount() - 1) {
 			Log.w(TAG, "BOTTOM REACHED!!!");
 			if(getYouTubeVideos != null)
-				new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout).executeInParallel();
+				new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout, false).executeInParallel();
 		}
 
 	}

--- a/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
@@ -42,10 +42,10 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 	public void onFragmentSelected() {
 		super.onFragmentSelected();
 
-		if (DownloadedVideosDb.getVideoDownloadsDb().isHasUpdated()) {
-			populateList();
-			DownloadedVideosDb.getVideoDownloadsDb().setHasUpdated(false);
-		}
+		populateList();
+//		if (DownloadedVideosDb.getVideoDownloadsDb().isHasUpdated()) {
+//			DownloadedVideosDb.getVideoDownloadsDb().setHasUpdated(false);
+//		}
 
 		displayDownloadsDisabledWarning();
 	}
@@ -89,17 +89,17 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 
 
 	private void populateList() {
-		new PopulateBookmarksTask().executeInParallel();
+		new PopulateDownloadsTask().executeInParallel();
 	}
 
 
 	/**
 	 * A task that:
-	 *   1. gets the current total number of bookmarks
+	 *   1. gets the current total number of downloads
 	 *   2. updated the UI accordingly (wrt step 1)
-	 *   3. get the bookmarked videos asynchronously.
+	 *   3. get the downloaded videos asynchronously.
 	 */
-	private class PopulateBookmarksTask extends AsyncTaskParallel<Void, Void, Integer> {
+	private class PopulateDownloadsTask extends AsyncTaskParallel<Void, Void, Integer> {
 
 		@Override
 		protected Integer doInBackground(Void... params) {
@@ -108,10 +108,10 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 
 
 		@Override
-		protected void onPostExecute(Integer numVideosBookmarked) {
+		protected void onPostExecute(Integer numVideosDownloaded) {
 			// If no videos have been bookmarked, show the text notifying the user, otherwise
 			// show the swipe refresh layout that contains the actual video grid.
-			if (numVideosBookmarked <= 0) {
+			if (numVideosDownloaded <= 0) {
 				swipeRefreshLayout.setVisibility(View.GONE);
 				noDownloadedVideosText.setVisibility(View.VISIBLE);
 			} else {


### PR DESCRIPTION
Always refresh the downloads list, and postpone the clearing of 'video list' until the new list is ready to add.