### PR TITLE
Save the base informations about the subscribed channels inside db

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsTable.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsTable.java
@@ -26,13 +26,43 @@ public class SubscriptionsTable {
 	public static final String COL_ID  = "_id";
 	public static final String COL_CHANNEL_ID = "Channel_Id";
 	public static final String COL_LAST_VISIT_TIME = "Last_Visit_Time";
+	public static final String COL_TITLE = "Title";
+	public static final String COL_DESCRIPTION = "Description";
+	public static final String COL_THUMBNAIL_NORMAL_URL = "Thumbnail_Normal_Url";
+	public static final String COL_BANNER_URL = "Banner_Url";
+	public static final String COL_SUBSCRIBER_COUNT = "Subscriber_Count";
+	public static final String[] ALL_COLUMNS = new String[]{
+			SubscriptionsTable.COL_CHANNEL_ID,
+			SubscriptionsTable.COL_TITLE,
+			SubscriptionsTable.COL_DESCRIPTION,
+			SubscriptionsTable.COL_BANNER_URL,
+			SubscriptionsTable.COL_THUMBNAIL_NORMAL_URL,
+			SubscriptionsTable.COL_SUBSCRIBER_COUNT,
+			SubscriptionsTable.COL_LAST_VISIT_TIME};
+
+	private static final String ADD_COLUMN = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN ";
 
 	public static String getCreateStatement() {
 		return "CREATE TABLE " + TABLE_NAME + " (" +
 				COL_ID         + " INTEGER PRIMARY KEY ASC, " +
 				COL_CHANNEL_ID + " TEXT UNIQUE NOT NULL, " +
-				COL_LAST_VISIT_TIME + " TIMESTAMP DEFAULT (strftime('%s', 'now')) " +
+				COL_TITLE      + " TEXT, " +
+				COL_DESCRIPTION     	+ " TEXT, " +
+				COL_THUMBNAIL_NORMAL_URL+ " TEXT, " +
+				COL_BANNER_URL      	+ " TEXT, " +
+				COL_SUBSCRIBER_COUNT	+ " INTEGER, " +
+				COL_LAST_VISIT_TIME 	+ " TIMESTAMP DEFAULT (strftime('%s', 'now')) " +
 		" )";
 	}
 
+
+	public static String[] getAddColumns() {
+		return new String[]{
+				ADD_COLUMN + COL_TITLE + " TEXT",
+				ADD_COLUMN + COL_DESCRIPTION + " TEXT",
+				ADD_COLUMN + COL_THUMBNAIL_NORMAL_URL + " TEXT",
+				ADD_COLUMN + COL_BANNER_URL + " TEXT",
+				ADD_COLUMN + COL_SUBSCRIBER_COUNT + " INTEGER"
+		};
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscriptionsBackupsManager.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/SubscriptionsBackupsManager.java
@@ -38,6 +38,7 @@ import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.Logger;
+import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.Tasks.GetSubscriptionVideosTask;
 import free.rm.skytube.businessobjects.db.SubscriptionsDb;
 import free.rm.skytube.businessobjects.db.Tasks.UnsubscribeFromAllChannelsTask;
@@ -404,7 +405,7 @@ public class SubscriptionsBackupsManager {
 		@Override
 		protected Integer doInBackground(final List<MultiSelectListPreferenceItem>... channels) {
 			for (MultiSelectListPreferenceItem channel : channels[0]) {
-				SubscriptionsDb.getSubscriptionsDb().subscribe(channel.id);
+				SubscriptionsDb.getSubscriptionsDb().subscribe(new YouTubeChannel(channel.id, null));
 			}
 
 			return channels[0].size();


### PR DESCRIPTION
This is to address #260. Currently the same network checks are executed as before on initialization, but maybe, this can be skipped, if every channel has recent enough informations.