### PR TITLE
Lazy loading of the videos on the tabs

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
@@ -60,6 +60,8 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 
 	private GridViewHolder activeGridViewHolder;
 
+	private boolean initialized = false;
+
 	private static final String TAG = VideoGridAdapter.class.getSimpleName();
 
 
@@ -128,8 +130,6 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 			// set current video category
 			this.currentVideoCategory = videoCategory;
 
-			// get the videos from the web asynchronously
-			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout, true).executeInParallel();
 		} catch (IOException e) {
 			Log.e(TAG, "Could not init " + videoCategory, e);
 			Toast.makeText(getContext(),
@@ -138,7 +138,6 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 			this.currentVideoCategory = null;
 		}
 	}
-
 
 
 	@Override
@@ -160,6 +159,16 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 	}
 
 	/**
+	 * Initialize the video list, if it's not yet initialized.
+	 */
+	public void initializeList() {
+		if (!initialized && getYouTubeVideos != null) {
+			initialized = true;
+			refresh(true);
+		}
+	}
+
+	/**
 	 * Refresh the video grid, by running the task to get the videos again.
 	 */
 	public void refresh() {
@@ -178,7 +187,8 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<YouTubeVideo, GridVi
 			if (clearVideosList) {
 				getYouTubeVideos.reset();
 			}
-
+			// now, we consider this as initialized - sometimes 'refresh' can be called before the initializeList is called.
+			initialized = true;
 			new GetYouTubeVideosTask(getYouTubeVideos, this, swipeRefreshLayout, clearVideosList).executeInParallel();
 		}
 	}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
@@ -74,6 +74,14 @@ public abstract class BaseVideosGridFragment extends TabFragment implements Swip
 		}
 	}
 
+	@Override
+	public void onFragmentSelected() {
+		super.onFragmentSelected();
+		if (videoGridAdapter != null) {
+			videoGridAdapter.initializeList();
+		}
+	}
+
 	/**
 	 * Set the layout resource (e.g. Subscriptions resource layout, R.id.grid_view, ...etc).
 	 */

--- a/app/src/main/java/free/rm/skytube/gui/fragments/ChannelBrowserFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/ChannelBrowserFragment.java
@@ -197,6 +197,7 @@ public class ChannelBrowserFragment extends FragmentEx {
 			viewPager.setOffscreenPageLimit(2);
 			viewPager.setAdapter(channelPagerAdapter);
 
+			this.channelVideosFragment.onFragmentSelected();
 
 			Glide.with(getActivity())
 					.load(channel.getThumbnailNormalUrl())

--- a/app/src/main/java/free/rm/skytube/gui/fragments/ChannelVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/ChannelVideosFragment.java
@@ -65,8 +65,4 @@ public class ChannelVideosFragment extends VideosGridFragment {
 	}
 
 
-	@Override
-	public void onFragmentSelected() {
-	}
-
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/PlaylistVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/PlaylistVideosFragment.java
@@ -68,6 +68,8 @@ public class PlaylistVideosFragment extends VideosGridFragment {
 				.apply(new RequestOptions().placeholder(R.drawable.banner_default))
 				.into(playlistBannerImageView);
 
+		// Force initialization
+		videoGridAdapter.initializeList();
 		return view;
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/SearchVideoGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/SearchVideoGridFragment.java
@@ -70,6 +70,8 @@ public class SearchVideoGridFragment extends VideosGridFragment {
 		// the app will call onCreateOptionsMenu() for when the user wants to search
 		setHasOptionsMenu(true);
 
+		// Enforce loading of the list
+		videoGridAdapter.initializeList();
 		return view;
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
@@ -64,6 +64,10 @@ public abstract class VideosGridFragment extends BaseVideosGridFragment {
 		gridView.setLayoutManager(new GridLayoutManager(getActivity(), getResources().getInteger(R.integer.video_grid_num_columns)));
 		gridView.setAdapter(videoGridAdapter);
 
+		// The fragment is already selected, we need to initialize the video grid
+		if (this.isFragmentSelected()) {
+			videoGridAdapter.initializeList();
+		}
 		return view;
 	}
 


### PR DESCRIPTION
Instead of sending a network requests for each of the tabs during initialization, it's better to do it, just before the tab is needed - so API calls can be reduced. 