### PR TITLE
Added preferred resolution on mobile network

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/VideoStream/StreamMetaDataList.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/VideoStream/StreamMetaDataList.java
@@ -17,12 +17,16 @@
 
 package free.rm.skytube.businessobjects.YouTube.VideoStream;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
 import android.util.Log;
 
 import java.util.ArrayList;
 
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
+
+import static free.rm.skytube.app.SkyTubeApp.getContext;
 
 /**
  * A list of {@link StreamMetaData}.
@@ -95,6 +99,20 @@ public class StreamMetaDataList extends ArrayList<StreamMetaData> {
 							.getString(SkyTubeApp.getStr(R.string.pref_key_preferred_res),
 										Integer.toString(VideoResolution.DEFAULT_VIDEO_RES_ID));
 
+		/*
+		 * TODO: this is a copy paste from MobileNetworkWarningDialog class isConnectedToMobile()
+		 * method. Define this method in another class and use it also here.
+		 */
+		final ConnectivityManager connMgr = (ConnectivityManager)
+				getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+		final android.net.NetworkInfo mobile = connMgr.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
+
+		// if on mobile network use the preferred resolution under mobile network if defined
+		if( mobile != null && mobile.isConnectedOrConnecting()) {
+			resIdValue = SkyTubeApp.getPreferenceManager()
+					.getString(SkyTubeApp.getStr(R.string.pref_key_preferred_res_mobile),
+							resIdValue);
+		}
 		return VideoResolution.videoResIdToVideoResolution(resIdValue);
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/preferences/VideoPlayerPreferenceFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/preferences/VideoPlayerPreferenceFragment.java
@@ -42,6 +42,11 @@ public class VideoPlayerPreferenceFragment extends PreferenceFragment {
 		resolutionPref.setEntries(VideoResolution.getAllVideoResolutionsNames());
 		resolutionPref.setEntryValues(VideoResolution.getAllVideoResolutionsIds());
 
+		// set up the list of available video resolutions on mobile network
+        ListPreference resolutionPrefMobile = (ListPreference) findPreference(getString(R.string.pref_key_preferred_res_mobile));
+		resolutionPrefMobile.setEntries(VideoResolution.getAllVideoResolutionsNames());
+		resolutionPrefMobile.setEntryValues(VideoResolution.getAllVideoResolutionsIds());
+
 		// if we are running an OSS version, then remove the last option (i.e. the "official" player
 		// option)
 		if (BuildConfig.FLAVOR.equals("oss")) {

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -7,6 +7,10 @@
 	<string name="pref_key_preferred_res" translatable="false">pref_preferred_resolution</string>
 	<string name="pref_summary_preferred_res">Select your preferred resolution:  %s</string>
 
+	<string name="pref_title_preferred_res_mobile">Preferred Resolution on Mobile Network</string>
+	<string name="pref_key_preferred_res_mobile" translatable="false">pref_preferred_resolution_mobile</string>
+	<string name="pref_summary_preferred_res_mobile">Select your preferred resolution:  %s</string>
+
 	<string name="pref_key_choose_player" translatable="false">pref_key_choose_player</string>
 	<string name="pref_title_choose_player">Video Player</string>
 	<string name="pref_summary_choose_player">Video Player to be used:  %s</string>

--- a/app/src/main/res/xml/preference_video_player.xml
+++ b/app/src/main/res/xml/preference_video_player.xml
@@ -24,6 +24,11 @@
 		android:summary="@string/pref_summary_preferred_res"/>
 
 	<ListPreference
+		android:key="@string/pref_key_preferred_res_mobile"
+		android:title="@string/pref_title_preferred_res_mobile"
+		android:summary="@string/pref_summary_preferred_res_mobile"/>
+
+	<ListPreference
 		android:key="@string/pref_key_choose_player"
 		android:title="@string/pref_title_choose_player"
 		android:summary="@string/pref_summary_choose_player"


### PR DESCRIPTION
Solved issue #392.

This is my first contribution to this project and in general to an android app, so please double check :)

I added a TODO because I think that the method isConnectedToMobile() of the class MobileNetworkWarningDialog should be in a class not related to the GUI in order to be called in other parts of the code. If you tell me in which class to put this method I can solve it.

If the preferred resolution on mobile network is not set, the general preferred resolution is used also under mobile network.
