### PR TITLE
Spelling: carges, - whitespaces

### DIFF
--- a/app/src/main/res/values/strings_downloads.xml
+++ b/app/src/main/res/values/strings_downloads.xml
@@ -2,7 +2,7 @@
 <resources>
 	<string name="download">Download</string>
 	<string name="downloads">Downloads</string>
-	<string name="warning_mobile_network_download">Your device is not connected to a Wi-Fi network.  To avoid potential extra data usage changes, it is recommended to connect to a Wi-Fi network.  Download video anyway?</string>
+	<string name="warning_mobile_network_download">Your device is not connected to a Wi-Fi network. To avoid potential extra data usage charges, it is recommended to connect to a Wi-Fi network. Download video anyway?</string>
 	<string name="download_video">Download Video</string>
 	<string name="starting_video_download">Downloading \'%s\'…</string>
 	<string name="video_download_stream_error">Could not download \'%s\'.</string>


### PR DESCRIPTION
As per https://github.com/ram-on/SkyTube/blob/6c03e5d048c86d77c528ea9484a0444a004d39a8/app/src/main/res/values/strings_youtube_player.xml#L14

Spotted by roptat at Weblate https://hosted.weblate.org/translate/skytube/downloads/fr/?checksum=5ad4e71edf305427