### PR TITLE
Don't show Feed refresh dialog when clicking on Feed tab when no chan…

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
@@ -372,6 +372,8 @@ public class SubscriptionsFeedFragment extends VideosGridFragment implements Get
 						showRefreshDialog();
 					}
 				}
+			} else {
+				refreshInProgress = false;
 			}
 		}
 


### PR DESCRIPTION
…nels are subscribed to.

While testing hidden tabs I noticed this. If you clear storage and start the app up, and then click on the Feeds Tab, it shows the refresh dialog even though no channels are subscribed.