### PR TITLE
Added Preference to select video download quality. Fulfills #428.

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/FileDownloader.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/FileDownloader.java
@@ -115,7 +115,8 @@ public abstract class FileDownloader implements Serializable, PermissionsActivit
 		DownloadManager.Request request = new DownloadManager.Request(remoteFileUri)
 				.setAllowedOverRoaming(allowedOverRoaming)
 				.setTitle(title)
-				.setDescription(description);
+				.setDescription(description)
+				.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
 
 		String videoDir = SkyTubeApp.getPreferenceManager().getString(SkyTubeApp.getStr(R.string.pref_key_video_download_folder), null);
 		if(videoDir != null) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
@@ -484,6 +484,10 @@ public class YouTubeVideo implements Serializable {
 	 *
 	 * @param listener Instance of {@link GetDesiredStreamListener} to pass the stream through.
 	 */
+	public void getDesiredStream(GetDesiredStreamListener listener, boolean forDownload) {
+		new GetVideoStreamTask(this, listener, forDownload).executeInParallel();
+	}
+
 	public void getDesiredStream(GetDesiredStreamListener listener) {
 		new GetVideoStreamTask(this, listener).executeInParallel();
 	}
@@ -560,7 +564,7 @@ public class YouTubeVideo implements Serializable {
 							String.format(getContext().getString(R.string.video_download_stream_error), getTitle()),
 							Toast.LENGTH_LONG).show();
 				}
-			});
+			}, true);
 		}
 	}
 

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetVideoStreamTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetVideoStreamTask.java
@@ -31,10 +31,17 @@ public class GetVideoStreamTask extends AsyncTaskParallel<Void, Exception, Strea
 
     private YouTubeVideo youTubeVideo;
     private GetDesiredStreamListener listener;
+    private boolean forDownload = false;
 
     public GetVideoStreamTask(YouTubeVideo youTubeVideo, GetDesiredStreamListener listener) {
         this.youTubeVideo = youTubeVideo;
         this.listener = listener;
+    }
+
+    public GetVideoStreamTask(YouTubeVideo youTubeVideo, GetDesiredStreamListener listener, boolean forDownload) {
+        this.youTubeVideo = youTubeVideo;
+        this.listener = listener;
+        this.forDownload = forDownload;
     }
 
     @Override
@@ -54,7 +61,7 @@ public class GetVideoStreamTask extends AsyncTaskParallel<Void, Exception, Strea
             listener.onGetDesiredStreamError(streamMetaDataList.getErrorMessage());
         } else {
             // get the desired stream based on user preferences
-            StreamMetaData desiredStream = streamMetaDataList.getDesiredStream();
+            StreamMetaData desiredStream = streamMetaDataList.getDesiredStream(forDownload);
 
             listener.onGetDesiredStream(desiredStream);
         }

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/VideoStream/StreamMetaDataList.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/VideoStream/StreamMetaDataList.java
@@ -57,8 +57,8 @@ public class StreamMetaDataList {
 	 *
 	 * @return The desired {@link StreamMetaData}.
 	 */
-	public StreamMetaData getDesiredStream() {
-		VideoResolution desiredVideoRes = getDesiredVideoResolution();
+	public StreamMetaData getDesiredStream(boolean forDownload) {
+		VideoResolution desiredVideoRes = getDesiredVideoResolution(forDownload);
 		Log.d(TAG, "Desired Video Res:  " + desiredVideoRes);
 		return getDesiredStream(desiredVideoRes);
 	}
@@ -92,9 +92,9 @@ public class StreamMetaDataList {
 	 *
 	 * @return Desired {@link VideoResolution}.
 	 */
-	private VideoResolution getDesiredVideoResolution() {
+	private VideoResolution getDesiredVideoResolution(boolean forDownload) {
 		String resIdValue = SkyTubeApp.getPreferenceManager()
-							.getString(SkyTubeApp.getStr(R.string.pref_key_preferred_res),
+							.getString(SkyTubeApp.getStr(forDownload ? R.string.pref_key_video_download_preferred_resolution : R.string.pref_key_preferred_res),
 										Integer.toString(VideoResolution.DEFAULT_VIDEO_RES_ID));
 
 		// if on mobile network use the preferred resolution under mobile network if defined

--- a/app/src/main/java/free/rm/skytube/gui/fragments/preferences/OthersPreferenceFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/preferences/OthersPreferenceFragment.java
@@ -39,6 +39,7 @@ import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.YouTube.ValidateYouTubeAPIKey;
+import free.rm.skytube.businessobjects.YouTube.VideoStream.VideoResolution;
 import free.rm.skytube.gui.businessobjects.adapters.SubsAdapter;
 
 /**
@@ -52,6 +53,9 @@ public class OthersPreferenceFragment extends PreferenceFragment implements Shar
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preference_others);
+
+		final SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
+		final SharedPreferences.Editor editor = pref.edit();
 
 		// Default tab
 		defaultTabPref = (ListPreference)findPreference(getString(R.string.pref_key_default_tab_name));
@@ -86,8 +90,7 @@ public class OthersPreferenceFragment extends PreferenceFragment implements Shar
 					.enableOptions(true)
 					.withResources(R.string.pref_popup_title_video_download_folder, R.string.ok, R.string.cancel)
 					.withChosenListener((dir, dirFile) -> {
-						SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
-						SharedPreferences.Editor editor = pref.edit();
+
 						editor.putString(getString(R.string.pref_key_video_download_folder), dir);
 						editor.apply();
 						folderChooser.setSummary(getString(R.string.pref_summary_video_download_folder, dir));
@@ -96,12 +99,18 @@ public class OthersPreferenceFragment extends PreferenceFragment implements Shar
 					.show();
 			return true;
 		});
-		SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
 		String dir = pref.getString(getString(R.string.pref_key_video_download_folder), null);
 		folderChooser.setSummary(getString(R.string.pref_summary_video_download_folder, dir != null ? dir : Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)));
 
 		MultiSelectListPreference hiddenTabsPref = (MultiSelectListPreference)findPreference(getString(R.string.pref_key_hide_tabs));
 		hiddenTabsPref.setEntryValues(tabListValues);
+
+		ListPreference videoResolutionPref = (ListPreference)findPreference(getString(R.string.pref_key_video_download_preferred_resolution));
+		String preferredVideoResolution = pref.getString(getString(R.string.pref_key_video_download_preferred_resolution), null);
+		String preferredVideoResolutionName = preferredVideoResolution == null ? "" : VideoResolution.getAllVideoResolutionsNames()[Integer.parseInt(preferredVideoResolution)];
+		videoResolutionPref.setSummary(getString(R.string.pref_video_download_preferred_resolution_summary, preferredVideoResolutionName));
+		videoResolutionPref.setEntries(VideoResolution.getAllVideoResolutionsNames());
+		videoResolutionPref.setEntryValues(VideoResolution.getAllVideoResolutionsIds());
 
 //		ListPreference feedNotificationPref = (ListPreference) findPreference(getString(R.string.pref_feed_notification_key));
 //		if(feedNotificationPref.getValue() == null) {
@@ -153,9 +162,12 @@ public class OthersPreferenceFragment extends PreferenceFragment implements Shar
 						displayRestartDialog(R.string.pref_youtube_api_key_default);
 					}
 				}
-			} else if (key.equals(getString(R.string.pref_key_subscriptions_alphabetical_order))){
+			} else if (key.equals(getString(R.string.pref_key_subscriptions_alphabetical_order))) {
 				SubsAdapter subsAdapter = SubsAdapter.get(getActivity());
 				subsAdapter.refreshSubsList();
+			} else if (key.equals(getString(R.string.pref_key_video_download_preferred_resolution))) {
+				ListPreference videoResolutionPref = (ListPreference)findPreference(getString(R.string.pref_key_video_download_preferred_resolution));
+				videoResolutionPref.setSummary(getString(R.string.pref_video_download_preferred_resolution_summary, videoResolutionPref.getEntry()));
 			}/*else if (key.equals(getString(R.string.pref_feed_notification_key))) {
 				ListPreference feedNotificationPref = (ListPreference) findPreference(key);
 				feedNotificationPref.setSummary(String.format(getString(R.string.pref_summary_feed_notification), feedNotificationPref.getEntry()));

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -541,16 +541,20 @@
 	<string name="pref_key_brightness_level" translatable="false">pref_key_brightness_level</string>
 
 	<string name="pref_category_downloads">Downloads</string>
-	<string name="pref_key_download_to_separate_directories">pref_key_download_to_separate_directories</string>
+	<string name="pref_key_download_to_separate_directories" translatable="false">pref_key_download_to_separate_directories</string>
 	<string name="pref_title_download_to_separate_directories">Download Videos Into Folders</string>
 	<string name="pref_summary_download_to_separate_directories">Videos are downloaded into folders based on the channel name.</string>
 
-	<string name="pref_key_video_download_folder">pref_key_video_download_folder</string>
+	<string name="pref_key_video_download_folder" translatable="false">pref_key_video_download_folder</string>
 	<string name="pref_popup_title_video_download_folder">Choose Folder</string>
 	<string name="pref_title_video_download_folder">Video Download Folder</string>
     <string name="pref_summary_video_download_folder">Videos are downloaded into this folder: %s</string>
 
-    <!--
+	<string name="pref_key_video_download_preferred_resolution" translatable="false">pref_key_video_preferred_resolution</string>
+	<string name="pref_video_download_preferred_resolution_title">Preferred Video Download Resolution</string>
+	<string name="pref_video_download_preferred_resolution_summary">Video downloads will prefer this resolution: %s</string>
+
+	<!--
         VIDEO BLOCKER
     -->
 	<string name="pref_video_blocker_category">Video Blocker</string>

--- a/app/src/main/res/xml/preference_others.xml
+++ b/app/src/main/res/xml/preference_others.xml
@@ -64,6 +64,10 @@
 			android:summary="@string/pref_summary_video_download_folder"
 			/>
 
+		<ListPreference
+			android:key="@string/pref_key_video_download_preferred_resolution"
+			android:title="@string/pref_video_download_preferred_resolution_title" />
+
 	</PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I chose to use a Preference as I thought it would be cumbersome to select the quality each and every time you try to download a video. 

From the couple videos I checked out, only 360p and 720p seem to be available in the StreamMetaDataList. However, I used all the available resolutions from the VideoResolution class.

Also, there's an option you can use for Android's DownloadManager to set a notification when a file is downloading and finished downloading, so I've added that to this branch.