### PR TITLE
Added ability to bookmark videos by sharing youtube url's from other …

### DIFF
--- a/app/src/extra/res/values/strings_bookmarks.xml
+++ b/app/src/extra/res/values/strings_bookmarks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="bookmark_share_label">SkyTube Extra Bookmark</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,16 @@
 			android:name=".gui.activities.PermissionsActivity"
 		    android:theme="@style/TransparentActivity">
 		</activity>
+
+		<activity android:name=".gui.activities.ShareBookmarkActivity"
+			android:theme="@style/TransparentActivity">
+			<intent-filter android:label="@string/bookmark_share_label">
+				<action android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="text/plain"/>
+			</intent-filter>
+
+		</activity>
 	</application>
 
 </manifest>

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
@@ -437,16 +437,21 @@ public class YouTubeVideo implements Serializable {
 		return isLiveStream;
 	}
 
-	public void bookmarkVideo(Context context, Menu menu) {
+	public boolean bookmarkVideo(Context context) {
+		return bookmarkVideo(context, null);
+	}
+
+	public boolean bookmarkVideo(Context context, Menu menu) {
 		boolean successBookmark = BookmarksDb.getBookmarksDb().add(this);
 		Toast.makeText(context,
 				successBookmark ? R.string.video_bookmarked : R.string.video_bookmarked_error,
 				Toast.LENGTH_LONG).show();
 
-		if (successBookmark) {
+		if (successBookmark && menu != null) {
 			menu.findItem(R.id.bookmark_video).setVisible(false);
 			menu.findItem(R.id.unbookmark_video).setVisible(true);
 		}
+		return successBookmark;
 	}
 
 	public void unbookmarkVideo(Context context, Menu menu) {

--- a/app/src/main/java/free/rm/skytube/gui/activities/ShareBookmarkActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/ShareBookmarkActivity.java
@@ -1,0 +1,43 @@
+package free.rm.skytube.gui.activities;
+
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import free.rm.skytube.R;
+import free.rm.skytube.businessobjects.GetVideoDetailsTask;
+import free.rm.skytube.gui.businessobjects.views.ClickableLinksTextView;
+
+/**
+ * Activity that receives an intent from other apps in order to bookmark a video from another app.
+ * This Activity uses a transparent theme, and finishes right away, so as not to take focus from the sharing app.s
+ */
+public class ShareBookmarkActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        boolean matched = false;
+
+        if(getIntent() != null) {
+            String text_data = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+            if(ClickableLinksTextView.videoPattern.matcher(text_data).matches()) {
+                matched = true;
+                new GetVideoDetailsTask(text_data, (videoUrl, video) -> {
+                    boolean bookmarked = video.bookmarkVideo(ShareBookmarkActivity.this);
+                    Toast.makeText(ShareBookmarkActivity.this,
+                            bookmarked ? R.string.video_bookmarked : R.string.video_bookmarked_error,
+                            Toast.LENGTH_LONG).show();
+                    finish();
+                }).executeInParallel();
+            }
+        }
+        if(!matched) {
+            Toast.makeText(ShareBookmarkActivity.this, R.string.bookmark_share_invalid_url, Toast.LENGTH_LONG).show();
+            finish();
+        }
+    }
+}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/views/ClickableLinksTextView.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/views/ClickableLinksTextView.java
@@ -52,6 +52,10 @@ import free.rm.skytube.gui.fragments.PlaylistVideosFragment;
  * party Android apps.
  */
 public class ClickableLinksTextView extends LinkConsumableTextView {
+	public static final Pattern videoPattern = Pattern.compile("http(?:s?):\\/\\/(?:www\\.)?youtu(?:be\\.com\\/watch\\?v=|\\.be\\/)([\\w\\-\\_]*)(&(amp;)?[\\w\\?=\\.]*)?");
+	public static final Pattern playlistPattern = Pattern.compile("^.*(youtu.be\\/|list=)([^#\\&\\?]*).*");
+	public static final Pattern channelPattern = Pattern.compile("(?:https|http)\\:\\/\\/(?:[\\w]+\\.)?youtube\\.com\\/(?:c\\/|channel\\/|user\\/)?([a-zA-Z0-9\\-]{1,})");
+
 
 	public ClickableLinksTextView(Context context) {
 		super(context);
@@ -88,9 +92,6 @@ public class ClickableLinksTextView extends LinkConsumableTextView {
 	 */
 	private void linkify() {
 		Link link = new Link(android.util.Patterns.WEB_URL);
-		final Pattern videoPattern = Pattern.compile("http(?:s?):\\/\\/(?:www\\.)?youtu(?:be\\.com\\/watch\\?v=|\\.be\\/)([\\w\\-\\_]*)(&(amp;)?[\\w\\?=\\.]*)?");
-		final Pattern playlistPattern = Pattern.compile("^.*(youtu.be\\/|list=)([^#\\&\\?]*).*");
-		final Pattern channelPattern = Pattern.compile("(?:https|http)\\:\\/\\/(?:[\\w]+\\.)?youtube\\.com\\/(?:c\\/|channel\\/|user\\/)?([a-zA-Z0-9\\-]{1,})");
 
 		// set the on click listener
 		link.setOnClickListener(clickedText -> {

--- a/app/src/main/res/values/strings_bookmarks.xml
+++ b/app/src/main/res/values/strings_bookmarks.xml
@@ -11,4 +11,6 @@
 	<string name="video_unbookmarked_error">Could not unbookmark the video.</string>
 
 	<string name="no_bookmarked_videos_text">You haven\'t bookmarked any videos yet.\n\nOnce you do, they will show up here.</string>
+	<string name="bookmark_share_label">SkyTube Bookmark</string>
+	<string name="bookmark_share_invalid_url">Only valid YouTube URL\'s can be bookmarked.</string>
 </resources>


### PR DESCRIPTION
…apps. "SkyTube Bookmark" and "SkyTube Extra Bookmark" will now show up when sharing text from other apps.

Unfortunately it doesn't look like it's possible to restrict it to only show when sharing a string that is a valid video url, but trying to do so will simply show a Toast that only valid url's can be bookmarked.

I've tested this by sharing videos from the reddit app I use (Relay), and it works fine :)