### PR TITLE
When the app is resumed and the previous connection to a Chromecast f…

### DIFF
--- a/app/src/extra/java/free/rm/skytube/gui/activities/BaseActivity.java
+++ b/app/src/extra/java/free/rm/skytube/gui/activities/BaseActivity.java
@@ -387,6 +387,7 @@ public abstract class BaseActivity extends AppCompatActivity implements MainActi
 		@Override
 		public void onSessionStartFailed(Session session, int i) {
 			YouTubePlayer.setConnectingToChromecast(false);
+			hideLoadingSpinner();
 		}
 
 		@Override
@@ -402,6 +403,7 @@ public abstract class BaseActivity extends AppCompatActivity implements MainActi
 		@Override
 		public void onSessionResumeFailed(Session session, int i) {
 			YouTubePlayer.setConnectingToChromecast(false);
+			hideLoadingSpinner();
 		}
 	}
 
@@ -553,6 +555,14 @@ public abstract class BaseActivity extends AppCompatActivity implements MainActi
 	public void showLoadingSpinner() {
 		if(chromecastLoadingSpinner != null)
 			chromecastLoadingSpinner.setVisibility(View.VISIBLE);
+	}
+
+	/**
+	 * Hide the Chromecast Loading Spinner
+	 */
+	public void hideLoadingSpinner() {
+		if(chromecastLoadingSpinner != null)
+			chromecastLoadingSpinner.setVisibility(View.GONE);
 	}
 
 	/**

--- a/app/src/extra/java/free/rm/skytube/gui/businessobjects/YouTubePlayer.java
+++ b/app/src/extra/java/free/rm/skytube/gui/businessobjects/YouTubePlayer.java
@@ -104,7 +104,7 @@ public class YouTubePlayer {
 		if(connectingToChromecast) {
 			((ChromecastListener)context).showLoadingSpinner();
 			// In the process of connecting to a chromecast. Wait 500ms and try again
-			new Handler().postDelayed(() -> launchOnChromecast(youTubeVideo, context), 500);
+			new Handler().postDelayed(() -> launch(youTubeVideo, context), 500);
 		} else {
 			if (context instanceof ChromecastListener) {
 				final PlaybackStatusDb.VideoWatchedStatus status = PlaybackStatusDb.getPlaybackStatusDb().getVideoWatchedStatus(youTubeVideo);


### PR DESCRIPTION
…ails (e.g. due to not being on wifi anymore), before the connection fails, attempting to play a video will wait until the connection to the Chromecast has been re-established. When this fails, the app should hide the spinner and play the video the device.

To elaborate, here are the steps to reproduce this bug which this branch fixes:
1) Start up the app, connect to wifi and connect to a Chromecast.
2) Kill the app (so it's not running anymore).
3) Disconnect from Wifi.
4) Fire the app up, and within the first few seconds of it opening, attempt to play a video.

The spinner will show, and just sit there spinning. This is caused by the fact that the app was previously connected to a Chromecast, so it attempts to reconnect. However, when this fails, the app keeps waiting for connection to be established, assuming it will eventually.

The new behavior will be that the spinner will show, but once the connection to the Chromecast fails, the spinner will be hidden, and the video will play on the device.