### PR TITLE
Minor dependency bumps:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // YouTube modules
-    implementation 'com.google.http-client:google-http-client-android:1.32.0'
+    implementation 'com.google.http-client:google-http-client-android:1.32.1'
     implementation 'com.google.apis:google-api-services-youtube:v3-rev20190827-1.30.1'
     implementation 'com.github.TeamNewPipe.NewPipeExtractor:extractor:0.17.3'
 
@@ -104,7 +104,7 @@ dependencies {
     implementation 'com.jakewharton:butterknife:10.2.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.10.3'
+    implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
     implementation 'com.afollestad.material-dialogs:core:0.9.5.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
     implementation 'com.klinkerapps:link_builder:1.6.1'


### PR DESCRIPTION
* Bump joda-time from 2.10.3 to 2.10.4
* Bump google-http-client-android from 1.32.0 to 1.32.1