### PR TITLE
Save the feed last updated time upon completion of fetching Feed vide…

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetSubscriptionVideosTask.java
@@ -17,7 +17,6 @@
 
 package free.rm.skytube.businessobjects.YouTube.Tasks;
 
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -93,6 +92,7 @@ public class GetSubscriptionVideosTask extends AsyncTaskParallel<Void, Void, Boo
 
 	@Override
 	protected void onPostExecute(Boolean changed) {
+		SkyTubeApp.getSettings().updateFeedsLastUpdateTime();
 		if (listener != null) {
 			listener.onAllChannelVideosFetched(changed);
 		}


### PR DESCRIPTION
…os when using the non-NewPipe method.

@gzsombor [This commit](https://github.com/ram-on/SkyTube/commit/039fa30f9346c3695f093bcf2c4069d7425f6769#diff-ea4f0d4a13add77b0c26f2dbaf4b46c0L116), where you switched to using a Semaphore for the multi-threading part of GetVideoSubscriptionVideosTask, omitted updating the last update time, resulting in a refresh getting kicked off every time the app was launched (or resumed). I'll note that this wasn't happening if something else had updated that last updated time, so you may have to wait up to 3 hours before you'll see this behavior (after switching to using the non-NewPipe backend).

I simply added a line to update the last updated time once all of the fetches were complete.