### PR TITLE
Fix #626 - db upgrade scenario.

### DIFF
--- a/app/src/main/java/free/rm/skytube/app/Utils.java
+++ b/app/src/main/java/free/rm/skytube/app/Utils.java
@@ -24,6 +24,9 @@ public class Utils {
         return  a == b || (a != null && a.equals(b));
     }
 
+    public static boolean isEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
 
     public static int hash(Object... obj) {
         return Arrays.hashCode(obj);

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsDb.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsDb.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 
 import free.rm.skytube.app.SkyTubeApp;
+import free.rm.skytube.app.Utils;
 import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
@@ -112,7 +113,13 @@ public class SubscriptionsDb extends SQLiteOpenHelperEx {
 			db.execSQL(LocalChannelTable.getCreateStatement());
 			try {
 				for (YouTubeChannel channel : getSubscribedChannels(db)) {
-					cacheChannel(db, channel);
+					if (!Utils.isEmpty(channel.getId()) &&
+							!Utils.isEmpty(channel.getTitle()) &&
+							!Utils.isEmpty(channel.getBannerUrl()) &&
+							!Utils.isEmpty(channel.getThumbnailNormalUrl()) &&
+							!Utils.isEmpty(channel.getDescription())) {
+						cacheChannel(db, channel);
+					}
 				}
 			} catch (IOException ex) {
 				Logger.e(this, "Unable to load subscribed channels to populate cache:" + ex.getMessage(), ex);

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetChannelInfo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetChannelInfo.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
+import free.rm.skytube.app.Utils;
 import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
@@ -79,7 +80,7 @@ public class GetChannelInfo extends AsyncTaskParallel<String, Void, YouTubeChann
     }
 
     private boolean needRefresh(YouTubeChannel channel) {
-        if (channel == null) {
+        if (channel == null || Utils.isEmpty(channel.getTitle())) {
             return true;
         }
         if (staleAcceptable) {


### PR DESCRIPTION
 The source of the problem is that in the old db version,
 there wasn't any information about the channel, apart from the ID -
and this was copied to the local cache table. If these kind of channels are filtered,
then it triggers a network re-fetch.