### PR TITLE
Fetch improvements

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/CardData.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/CardData.java
@@ -7,6 +7,7 @@ public class CardData implements Serializable {
     protected String              title;
     protected String              description;
     protected Long                publishTimestamp;
+    protected Boolean             publishTimestampApproximate;
     protected String              thumbnailUrl;
 
     /**
@@ -43,6 +44,14 @@ public class CardData implements Serializable {
 
     public final void setDescription(String description) {
         this.description = description;
+    }
+
+    public void setPublishTimestampApproximate(Boolean publishTimestampApproximate) {
+        this.publishTimestampApproximate = publishTimestampApproximate;
+    }
+
+    public Boolean getPublishTimestampApproximate() {
+        return publishTimestampApproximate;
     }
 
     public final Long getPublishTimestamp() {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/CardData.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/CardData.java
@@ -7,7 +7,7 @@ public class CardData implements Serializable {
     protected String              title;
     protected String              description;
     protected Long                publishTimestamp;
-    protected Boolean             publishTimestampApproximate;
+    protected Boolean             publishTimestampExact;
     protected String              thumbnailUrl;
 
     /**
@@ -46,12 +46,12 @@ public class CardData implements Serializable {
         this.description = description;
     }
 
-    public void setPublishTimestampApproximate(Boolean publishTimestampApproximate) {
-        this.publishTimestampApproximate = publishTimestampApproximate;
+    public void setPublishTimestampExact(Boolean publishTimestampExact) {
+        this.publishTimestampExact = publishTimestampExact;
     }
 
-    public Boolean getPublishTimestampApproximate() {
-        return publishTimestampApproximate;
+    public Boolean getPublishTimestampExact() {
+        return publishTimestampExact;
     }
 
     public final Long getPublishTimestamp() {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
@@ -176,7 +176,7 @@ public class YouTubeVideo extends CardData implements Serializable {
 	}
 
         public YouTubeVideo(String id, String title, String description, long durationInSeconds, YouTubeChannel channel, long viewCount,
-							Long publishDate, Boolean publishDateApproximation, String thumbnailUrl) {
+							Long publishDate, Boolean publishDateExact, String thumbnailUrl) {
             this.id = id;
             this.title = title;
             this.description = description;
@@ -186,7 +186,7 @@ public class YouTubeVideo extends CardData implements Serializable {
                 this.setPublishTimestamp(publishDate);
                 this.publishDate = new DateTime(publishDate);
             }
-            this.setPublishTimestampApproximate(publishDateApproximation);
+            this.setPublishTimestampExact(publishDateExact);
             this.thumbnailMaxResUrl = thumbnailUrl;
             this.thumbnailUrl = thumbnailUrl;
             this.channel = channel;

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/POJOs/YouTubeVideo.java
@@ -44,8 +44,6 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import free.rm.skytube.BuildConfig;
 import free.rm.skytube.R;
@@ -71,20 +69,12 @@ public class YouTubeVideo extends CardData implements Serializable {
 	 * Channel (only id and name are set).
 	 */
 	private YouTubeChannel channel;
-	/**
-	 * The total number of 'likes' - as a localized string!
-	 */
-	private String likeCount;
 
 	/**
 	 * The total number of 'likes'.
 	 */
 	private Long likeCountNumber;
 
-	/**
-	 * The total number of 'dislikes' - as a localized string!
-	 */
-	private String dislikeCount;
 
 	/**
 	 * The total number of 'dislikes'.
@@ -92,9 +82,8 @@ public class YouTubeVideo extends CardData implements Serializable {
 	private Long dislikeCountNumber;
 
 	/**
-	 * The percentage of people that thumbs-up this video (format:  "<percentage>%").
+	 * The percentage of people that thumbs-up this video.
 	 */
-	private String thumbsUpPercentageStr;
 	private int thumbsUpPercentage;
 	/**
 	 * Video duration string (e.g. "5:15").
@@ -186,7 +175,8 @@ public class YouTubeVideo extends CardData implements Serializable {
 		this.viewsCount = String.format(getStr(R.string.views), viewsCountInt);
 	}
 
-        public YouTubeVideo(String id, String title, String description, long durationInSeconds, YouTubeChannel channel, long viewCount, Long publishDate, String thumbnailUrl) {
+        public YouTubeVideo(String id, String title, String description, long durationInSeconds, YouTubeChannel channel, long viewCount,
+							Long publishDate, Boolean publishDateApproximation, String thumbnailUrl) {
             this.id = id;
             this.title = title;
             this.description = description;
@@ -196,20 +186,21 @@ public class YouTubeVideo extends CardData implements Serializable {
                 this.setPublishTimestamp(publishDate);
                 this.publishDate = new DateTime(publishDate);
             }
+            this.setPublishTimestampApproximate(publishDateApproximation);
             this.thumbnailMaxResUrl = thumbnailUrl;
             this.thumbnailUrl = thumbnailUrl;
             this.channel = channel;
+            this.thumbsUpPercentage = -1;
         }
 
 	/**
-	 * Sets the {@link #thumbsUpPercentageStr}, i.e. the percentage of people that thumbs-up this video
+	 * Sets the {@link #thumbsUpPercentage}, i.e. the percentage of people that thumbs-up this video
 	 * (format:  "<percentage>%").
 	 *
 	 * @param likedCountInt	Total number of "likes".
 	 * @param dislikedCountInt Total number of "dislikes".
 	 */
 	public void setLikeDislikeCount(Long likedCountInt, Long dislikedCountInt) {
-		String fullPercentageStr = null;
 		this.thumbsUpPercentage = -1;
 
 		// some videos do not allow users to like/dislike them:  hence likedCountInt / dislikedCountInt
@@ -223,13 +214,10 @@ public class YouTubeVideo extends CardData implements Serializable {
 			if (totalVoteCount != 0) {
 				this.thumbsUpPercentage = (int) Math.round((double)likedCount*100/totalVoteCount);
 
-				// round the liked percentage to 0 decimal places and convert it to string
-				fullPercentageStr = String.valueOf(thumbsUpPercentage) + "%";
 			}
 		}
 		this.likeCountNumber = likedCountInt;
 		this.dislikeCountNumber = dislikedCountInt;
-		this.thumbsUpPercentageStr = fullPercentageStr;
 	}
 
 	/**
@@ -269,7 +257,7 @@ public class YouTubeVideo extends CardData implements Serializable {
 	 * @return True if the video allows the users to like/dislike it.
 	 */
 	public boolean isThumbsUpPercentageSet() {
-		return (thumbsUpPercentageStr != null);
+		return (thumbsUpPercentage >= 0);
 	}
 
 	/**
@@ -285,7 +273,8 @@ public class YouTubeVideo extends CardData implements Serializable {
 	 * video does not allow the users to like/dislike it.  Refer to {@link #isThumbsUpPercentageSet}.
 	 */
 	public String getThumbsUpPercentageStr() {
-		return thumbsUpPercentageStr;
+		// round the liked percentage to 0 decimal places and convert it to string
+		return thumbsUpPercentage >= 0 ? String.valueOf(thumbsUpPercentage) + "%" : null;
 	}
 
 	/**
@@ -296,7 +285,7 @@ public class YouTubeVideo extends CardData implements Serializable {
 		if (likeCountNumber != null) {
 			return String.format(Locale.getDefault(), "%,d", likeCountNumber);
 		}
-		return likeCount;
+		return null;
 	}
 
 	/**
@@ -314,7 +303,7 @@ public class YouTubeVideo extends CardData implements Serializable {
 		if (dislikeCountNumber != null) {
 			return String.format(Locale.getDefault(), "%,d", dislikeCountNumber);
 		}
-		return dislikeCount;
+		return null;
 	}
 
 	/**

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
@@ -69,8 +69,6 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
 
     @Override
     protected Boolean doInBackground(Void... params) {
-        Set<String> alreadyKnownVideos = subscriptionsDb.getSubscribedChannelVideos();
-
         AtomicBoolean changed = new AtomicBoolean(false);
         CountDownLatch countDown = new CountDownLatch(channels.size());
 
@@ -83,6 +81,7 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
 
                     @Override
                     protected Integer doInBackground(Void... voids) {
+                        Set<String> alreadyKnownVideos = subscriptionsDb.getSubscribedChannelVideosByChannel(dbChannel.getId());
                         List<YouTubeVideo> newVideos = fetchVideos(alreadyKnownVideos, dbChannel);
                         List<YouTubeVideo> detailedList = new ArrayList<>();
                         if (!newVideos.isEmpty()) {
@@ -90,6 +89,10 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
                                 YouTubeVideo details;
                                 try {
                                     details = NewPipeService.get().getDetails(vid.getId());
+                                    if (Boolean.FALSE.equals(vid.getPublishTimestampApproximate())) {
+                                        details.setPublishTimestamp(vid.getPublishTimestamp());
+                                        details.setPublishTimestampApproximate(vid.getPublishTimestampApproximate());
+                                    }
                                     details.setChannel(dbChannel);
                                     detailedList.add(details);
                                 } catch (ExtractionException | IOException e) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
@@ -148,7 +148,7 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
             Predicate<YouTubeVideo> predicate = video -> alreadyKnownVideos.contains(video.getId());
             // If we found a video which is already added to the db, no need to check the videos after,
             // assume, they are older, and already seen
-            predicate.removeAfter(videos);
+            predicate.removeIf(videos);
             return videos;
         } catch (ExtractionException | IOException e) {
             Logger.e(this, "Error during fetching channel page for " + dbChannel + ",msg:" + e.getMessage(), e);

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
@@ -144,7 +144,7 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
 
     private List<YouTubeVideo> fetchVideos(Set<String> alreadyKnownVideos, YouTubeChannel dbChannel) {
         try {
-            List<YouTubeVideo> videos = NewPipeService.get().getChannelVideos(dbChannel.getId());
+            List<YouTubeVideo> videos = NewPipeService.get().getVideosFromFeedOrFromChannel(dbChannel.getId());
             Predicate<YouTubeVideo> predicate = video -> alreadyKnownVideos.contains(video.getId());
             // If we found a video which is already added to the db, no need to check the videos after,
             // assume, they are older, and already seen

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.safety.Whitelist;
-import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.ServiceList;

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
@@ -302,7 +302,11 @@ public class NewPipeService {
         @NonNull
         @Override
         public String toString() {
-            return "[time= " + sdf.format(new Date(timestamp)) + ",exact=" + exact + ']';
+            try {
+                return "[time= " + sdf.format(new Date(timestamp)) + ",exact=" + exact + ']';
+            } catch (Exception e){
+                return "[incorrect time= "+timestamp+" ,exact=" + exact + ']';
+            }
         }
     }
 

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/Pager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/Pager.java
@@ -28,7 +28,6 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
 import free.rm.skytube.businessobjects.Logger;
-import free.rm.skytube.businessobjects.YouTube.POJOs.CardData;
 
 
 /**

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
@@ -95,10 +95,10 @@ public class VideoPager extends Pager<InfoItem, CardData> {
     }
 
     private YouTubeVideo convert(StreamInfoItem item, String id) throws ParsingException {
-        Long publishDate = NewPipeService.getPublishDate(item.getUploadDate());
+        NewPipeService.DateInfo date = new NewPipeService.DateInfo(item.getUploadDate());
         YouTubeChannel ch = channel != null ? channel : new YouTubeChannel(item.getUploaderUrl(), item.getUploaderName());
         return new YouTubeVideo(id, item.getName(), null, item.getDuration(), ch,
-                item.getViewCount(), publishDate, NewPipeService.getThumbnailUrl(id));
+                item.getViewCount(), date.timestamp, date.approximation, NewPipeService.getThumbnailUrl(id));
     }
 
     private CardData convert(PlaylistInfoItem playlistInfoItem, String id) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
@@ -94,11 +94,12 @@ public class VideoPager extends Pager<InfoItem, CardData> {
         return result;
     }
 
-    private YouTubeVideo convert(StreamInfoItem item, String id) throws ParsingException {
+    private YouTubeVideo convert(StreamInfoItem item, String id) {
         NewPipeService.DateInfo date = new NewPipeService.DateInfo(item.getUploadDate());
+        Logger.i(this, "item %s, title=%s at %s", id, item.getName(), date);
         YouTubeChannel ch = channel != null ? channel : new YouTubeChannel(item.getUploaderUrl(), item.getUploaderName());
         return new YouTubeVideo(id, item.getName(), null, item.getDuration(), ch,
-                item.getViewCount(), date.timestamp, date.approximation, NewPipeService.getThumbnailUrl(id));
+                item.getViewCount(), date.timestamp, date.exact, NewPipeService.getThumbnailUrl(id));
     }
 
     private CardData convert(PlaylistInfoItem playlistInfoItem, String id) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/VideoPager.java
@@ -83,7 +83,7 @@ public class VideoPager extends Pager<InfoItem, CardData> {
         return result;
     }
 
-    public List<YouTubeVideo> getNextPageAsVideos() throws ParsingException, IOException, ExtractionException {
+    public List<YouTubeVideo> getNextPageAsVideos() throws IOException, ExtractionException {
         List<CardData> cards = getNextPage();
         List<YouTubeVideo> result = new ArrayList<>(cards.size());
         for (CardData cardData: cards) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsVideosTable.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/SubscriptionsVideosTable.java
@@ -29,6 +29,8 @@ public class SubscriptionsVideosTable {
 	public static final String COL_RETRIEVAL_TS = "Retrieval_Timestamp";
 	public static final String COL_PUBLISH_TS = "Publish_Timestamp";
 
+	public static final String COL_YOUTUBE_VIDEO_ID_EQUALS_TO = SubscriptionsVideosTable.COL_YOUTUBE_VIDEO_ID + " = ?";
+
 	static final String[] ALL_COLUMNS_FOR_EXTRACT = new String[] {
 			COL_CHANNEL_ID,
 			COL_YOUTUBE_VIDEO_ID,

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetSubscriptionsVideosFromDb.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetSubscriptionsVideosFromDb.java
@@ -51,8 +51,7 @@ public class GetSubscriptionsVideosFromDb extends GetYouTubeVideos {
 			} else {
 				YouTubeVideo last = result.get(result.size() -1);
 				lastVideoId = last.getId();
-				//lastVideoPublishTimestamp = last.getPublishDate().getValue();
-				lastVideoPublishTimestamp = last.getRetrievalTimestamp();//last.getPublishDate().getValue();
+				lastVideoPublishTimestamp = last.getPublishTimestamp();
 			}
 
 			return new ArrayList<>(result);

--- a/app/src/main/java/free/rm/skytube/gui/fragments/preferences/OthersPreferenceFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/preferences/OthersPreferenceFragment.java
@@ -20,16 +20,13 @@ package free.rm.skytube.gui.fragments.preferences;
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.os.Environment;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.MultiSelectListPreference;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
 import android.widget.Toast;
 
-import com.obsez.android.lib.filechooser.ChooserDialog;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +37,6 @@ import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeAPIKey;
 import free.rm.skytube.businessobjects.YouTube.ValidateYouTubeAPIKey;
-import free.rm.skytube.businessobjects.YouTube.VideoStream.VideoResolution;
 import free.rm.skytube.gui.businessobjects.adapters.SubsAdapter;
 
 /**


### PR DESCRIPTION
* use FeedExtractor for subscription fetching, which provides better publish timestamps
* sort the subscription according the publish time.
* Update videos from subscribed channels with the latest, fetched timestamp, so recent, not exact timestamps could be corrected.