### PR TITLE
Hide the Block Channel menu item when the Video Blocker is not enabled.

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/BlockedVideosDialog.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/BlockedVideosDialog.java
@@ -53,7 +53,7 @@ public class BlockedVideosDialog extends SkyTubeMaterialDialog {
 		super(context);
 
 		if (blockedVideos.isEmpty()) {
-			// if no videos have been blocked, the ask the user is he wants to configure the
+			// if no videos have been blocked, then ask the user if they want to configure the
 			// preferences of the video blocker...
 			title(R.string.pref_video_blocker_category);
 			content(R.string.no_videos_blocked);

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/GridViewHolder.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/GridViewHolder.java
@@ -282,6 +282,11 @@ public class GridViewHolder extends RecyclerView.ViewHolder implements Serializa
 			popupMenu.getMenu().findItem(R.id.delete_download).setVisible(false);
 			popupMenu.getMenu().findItem(R.id.download_video).setVisible(online);
 		}
+		if(SkyTubeApp.getPreferenceManager().getBoolean(context.getString(R.string.pref_key_enable_video_blocker), true)) {
+			popupMenu.getMenu().findItem(R.id.block_channel).setVisible(true);
+		} else {
+			popupMenu.getMenu().findItem(R.id.block_channel).setVisible(false);
+		}
 		popupMenu.setOnMenuItemClickListener(item -> {
 			switch(item.getItemId()) {
 				case R.id.menu_open_video_with:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The video options popup menu should hide the 'Block Channel' button when the Video Blocker is not enabled.