### PR TITLE
Catch RuntimeExceptions coming from NewPipeExtractor

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeChannelVideos.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeChannelVideos.java
@@ -16,12 +16,10 @@
  */
  package free.rm.skytube.businessobjects.YouTube;
 
-import java.io.IOException;
-
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import free.rm.skytube.app.Utils;
+import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeException;
 import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeService;
 import free.rm.skytube.businessobjects.YouTube.newpipe.VideoPager;
 
@@ -51,7 +49,7 @@ public class NewPipeChannelVideos extends NewPipeVideos<StreamInfoItem> implemen
     }
 
     @Override
-    protected VideoPager createNewPager() throws ExtractionException, IOException {
+    protected VideoPager createNewPager() throws NewPipeException {
         Utils.requireNonNull(channelId, "channelId missing");
         return NewPipeService.get().getChannelPager(channelId);
     }

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeVideoBySearch.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeVideoBySearch.java
@@ -16,11 +16,9 @@
  */
 package free.rm.skytube.businessobjects.YouTube;
 
-import java.io.IOException;
-
 import org.schabi.newpipe.extractor.InfoItem;
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 
+import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeException;
 import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeService;
 import free.rm.skytube.businessobjects.YouTube.newpipe.VideoPager;
 
@@ -34,7 +32,7 @@ public class NewPipeVideoBySearch extends NewPipeVideos<InfoItem> {
     }
 
     @Override
-    protected VideoPager createNewPager() throws ExtractionException, IOException {
+    protected VideoPager createNewPager() throws NewPipeException {
         return NewPipeService.get().getSearchResult(query);
     }
 

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeVideos.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/NewPipeVideos.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.CardData;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
+import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeException;
 import free.rm.skytube.businessobjects.YouTube.newpipe.VideoPager;
 
 /**
@@ -37,10 +38,10 @@ public abstract class NewPipeVideos<ITEM extends InfoItem> extends GetYouTubeVid
 
     private VideoPager pager;
 
-    protected abstract VideoPager createNewPager() throws ExtractionException, IOException;
+    protected abstract VideoPager createNewPager() throws NewPipeException;
 
     @Override
-    public void init() throws IOException {
+    public void init() {
     }
 
     @Override
@@ -48,7 +49,7 @@ public abstract class NewPipeVideos<ITEM extends InfoItem> extends GetYouTubeVid
         if (pager == null) {
             try {
                 pager = createNewPager();
-            } catch (ExtractionException | IOException e) {
+            } catch (Exception e) {
                 Logger.e(this, "An error has occurred while getting videos:" + e.getMessage(), e);
                 setLastException(e);
                 return Collections.emptyList();
@@ -56,7 +57,7 @@ public abstract class NewPipeVideos<ITEM extends InfoItem> extends GetYouTubeVid
         }
         try {
             return pager.getNextPage();
-        } catch (IOException | ExtractionException e) {
+        } catch (Exception e) {
             Logger.e(this, "An error has occurred while getting videos:" + e.getMessage(), e);
             setLastException(e);
             return Collections.emptyList();

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/Tasks/GetBulkSubscriptionVideosTask.java
@@ -34,6 +34,7 @@ import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
+import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeException;
 import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeService;
 import free.rm.skytube.businessobjects.db.SubscriptionsDb;
 import free.rm.skytube.businessobjects.utils.Predicate;
@@ -166,9 +167,8 @@ public class GetBulkSubscriptionVideosTask extends AsyncTaskParallel<Void, GetBu
             // assume, they are older, and already seen
             predicate.removeIf(videos);
             return videos;
-        } catch (ExtractionException | IOException e) {
+        } catch (NewPipeException e) {
             Logger.e(this, "Error during fetching channel page for " + channelId + ",msg:" + e.getMessage(), e);
-            e.printStackTrace();
             return Collections.EMPTY_LIST;
         }
     }

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/CommentPager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/CommentPager.java
@@ -19,7 +19,6 @@ package free.rm.skytube.businessobjects.YouTube.newpipe;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ public class CommentPager extends Pager<CommentsInfoItem, YouTubeCommentThread> 
     }
 
     @Override
-    protected List<YouTubeCommentThread> extract(ListExtractor.InfoItemsPage<CommentsInfoItem> page) throws ParsingException {
+    protected List<YouTubeCommentThread> extract(ListExtractor.InfoItemsPage<CommentsInfoItem> page) {
         List<YouTubeCommentThread> result = new ArrayList<>(page.getItems().size());
         for (CommentsInfoItem infoItem : page.getItems()) {
             YouTubeCommentThread thread = new YouTubeCommentThread(new YouTubeComment(

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeException.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeException.java
@@ -1,0 +1,27 @@
+/*
+ * SkyTube
+ * Copyright (C) 2020  Zsombor Gegesy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (version 3 of the License).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package free.rm.skytube.businessobjects.YouTube.newpipe;
+
+public class NewPipeException extends Exception {
+    public NewPipeException(String message) {
+        super(message);
+    }
+
+    public NewPipeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/PlaylistPager.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/PlaylistPager.java
@@ -2,7 +2,6 @@ package free.rm.skytube.businessobjects.YouTube.newpipe;
 
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.StreamingService;
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -19,7 +18,7 @@ class PlaylistPager extends Pager<StreamInfoItem, YouTubePlaylist>  {
     }
 
     @Override
-    protected List<YouTubePlaylist> extract(ListExtractor.InfoItemsPage<StreamInfoItem> page) throws ParsingException {
+    protected List<YouTubePlaylist> extract(ListExtractor.InfoItemsPage<StreamInfoItem> page) {
         List<YouTubePlaylist> result = new ArrayList<>(page.getItems().size());
         Logger.i(this, "extract from %s, items: %s", page, page.getItems().size());
         for (StreamInfoItem item: page.getItems()) {

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetChannelInfo.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/Tasks/GetChannelInfo.java
@@ -30,6 +30,7 @@ import free.rm.skytube.businessobjects.AsyncTaskParallel;
 import free.rm.skytube.businessobjects.Logger;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannelInterface;
+import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeException;
 import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeService;
 import free.rm.skytube.businessobjects.db.SubscriptionsDb;
 
@@ -80,7 +81,7 @@ public class GetChannelInfo extends AsyncTaskParallel<String, Void, YouTubeChann
             try {
                 channel = NewPipeService.get().getChannelDetails(channelId);
                 db.cacheChannel(channel);
-            } catch (ExtractionException | IOException e) {
+            } catch (NewPipeException | RuntimeException e) {
                 exception = e;
             }
         }


### PR DESCRIPTION
and wrap it into NewPipeException, so it wont became fatal - fixes #703 