### PR TITLE
Enable running on older Androids

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 
     // YouTube modules
-    implementation 'com.google.http-client:google-http-client-android:1.34.2'
+    implementation 'com.github.SkyTubeTeam.google-http-java-client:google-http-client-android:1.34.3.1'
 
     implementation ('com.google.apis:google-api-services-youtube:v3-rev20200312-1.30.9') {
         exclude group: 'com.google.http-client', module:'google-http-client'

--- a/app/src/main/java/free/rm/skytube/businessobjects/TLSSocketFactory.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/TLSSocketFactory.java
@@ -1,0 +1,118 @@
+package free.rm.skytube.businessobjects;
+import android.util.Log;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * This is an extension of the SSLSocketFactory which enables TLS 1.2 and 1.1.
+ * Created for usage on Android 4.1-4.4 devices, which haven't enabled those by default.
+ *
+ * Based on TLSSocketFactoryCompat from NewPipe.
+ */
+public class TLSSocketFactory extends SSLSocketFactory {
+    private static TLSSocketFactory instance = null;
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    static TLSSocketFactory getInstance() throws NoSuchAlgorithmException, KeyManagementException {
+        if (instance != null) {
+            return instance;
+        }
+        return instance = new TLSSocketFactory();
+    }
+
+    TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    public static void setAsDefault() {
+        try {
+            HttpsURLConnection.setDefaultSSLSocketFactory(getInstance());
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            Log.e("TLSSocketFactory", "Setup failed: "+e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if (socket != null && (socket instanceof SSLSocket)) {
+            String[] protocols = filterTLS((SSLSocket) socket);
+            if (protocols.length > 0) {
+                ((SSLSocket) socket).setEnabledProtocols(protocols);
+            }
+        }
+        return socket;
+    }
+
+    private static final String TLS_v1 = "TLSv1";
+    private static final String TLS_v1_1 = "TLSv1.1";
+    private static final String TLS_v1_2 = "TLSv1.2";
+    private static final String[] TLS_VERSIONS = {TLS_v1_2, TLS_v1_1, TLS_v1 };
+
+    private static String[] filterTLS(SSLSocket sslSocket) {
+        List<String> supported = Arrays.asList(sslSocket.getSupportedProtocols());
+        Log.i("TLSSocketFactory", "is TLS enabled in server:" + supported);
+        List<String> result = new ArrayList<>();
+        for (String tlsVersion : TLS_VERSIONS) {
+            if (supported.contains(tlsVersion)) {
+                result.add(tlsVersion);
+            }
+        }
+        Log.i("TLSSocketFactory", "Enabled protocols: "+result);
+        return result.toArray(new String[result.size()]);
+    }
+}

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.core.content.ContextCompat;
@@ -50,6 +51,7 @@ import butterknife.ButterKnife;
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.Logger;
+import free.rm.skytube.businessobjects.TLSSocketFactory;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;
 import free.rm.skytube.businessobjects.YouTube.VideoBlocker;
@@ -104,6 +106,11 @@ public class MainActivity extends BaseActivity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+
+		// To enable downloading with https on pre-kitkat devices.
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+			TLSSocketFactory.setAsDefault();
+		}
 
 		// check for updates (one time only)
 		if (!updatesCheckerTaskRan) {


### PR DESCRIPTION
Using a forked google-http-client, and some hacks around the TLS handling it is possible to run the app again on Android API 14 (or more), with some limitations.

Fixes #659 