### PR TITLE
Memory leak debug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,6 +131,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.multidex:multidex:2.0.1' // as we have over 65536 lines of code...
 
+    // debugImplementation because LeakCanary should only run in debug builds.
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
+
     // proprietary module
     extraImplementation files('libs/YouTubeAndroidPlayerApi.jar')
     extraImplementation 'com.android.support:mediarouter-v7:28.0.0'

--- a/app/src/main/java/free/rm/skytube/app/Settings.java
+++ b/app/src/main/java/free/rm/skytube/app/Settings.java
@@ -22,6 +22,10 @@ import androidx.preference.PreferenceManager ;
 
 import androidx.annotation.StringRes;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import free.rm.skytube.R;
 import free.rm.skytube.app.enums.Policy;
 
@@ -49,6 +53,10 @@ public class Settings {
 
     public boolean isDownloadToSeparateFolders() {
         return getPreference(R.string.pref_key_download_to_separate_directories,false);
+    }
+
+    public Set<String> getHiddenTabs() {
+        return getPreference(R.string.pref_key_hide_tabs, Collections.emptySet());
     }
 
     public Policy getWarningMobilePolicy() {
@@ -159,6 +167,10 @@ public class Settings {
 
     private boolean getPreference(String preference, boolean defaultValue) {
         return getSharedPreferences().getBoolean(preference, defaultValue);
+    }
+
+    private Set<String> getPreference(@StringRes int resId, Set<String> defaultValue) {
+        return getSharedPreferences().getStringSet(app.getStr(resId), defaultValue);
     }
 
     private SharedPreferences getSharedPreferences() {

--- a/app/src/main/java/free/rm/skytube/app/Settings.java
+++ b/app/src/main/java/free/rm/skytube/app/Settings.java
@@ -65,6 +65,10 @@ public class Settings {
         return Policy.valueOf(currentValue.toUpperCase());
     }
 
+    public boolean isDisableSearchHistory() {
+        return getSharedPreferences().getBoolean(app.getStr(R.string.pref_key_disable_search_history), false);
+    }
+
     public void setWarningMobilePolicy(Policy warnPolicy) {
         setPreference(R.string.pref_key_mobile_network_usage_policy, warnPolicy.name().toLowerCase());
     }

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/BookmarksDb.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/BookmarksDb.java
@@ -32,7 +32,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.app.Utils;
@@ -53,7 +55,7 @@ public class BookmarksDb extends SQLiteOpenHelperEx implements OrderableDatabase
 	private static final int DATABASE_VERSION = 1;
 	private static final String DATABASE_NAME = "bookmarks.db";
 
-	private List<BookmarksDbListener> listeners = new ArrayList<>();
+	private final Set<BookmarksDbListener> listeners = new HashSet<>();
 
 
 	private BookmarksDb(Context context) {
@@ -308,11 +310,18 @@ public class BookmarksDb extends SQLiteOpenHelperEx implements OrderableDatabase
 	 *
 	 * @param listener The Listener (which implements BookmarksDbListener) to add.
 	 */
-	public void addListener(BookmarksDbListener listener) {
-		if(!listeners.contains(listener))
-			listeners.add(listener);
+	public void addListener(@NonNull BookmarksDbListener listener) {
+		listeners.add(listener);
 	}
 
+	/**
+	 * Remove the Listener
+	 *
+	 * @param listener The Listener (which implements BookmarksDbListener) to remove.
+	 */
+	public void removeListener(@NonNull BookmarksDbListener listener) {
+		listeners.remove(listener);
+	}
 
 	/**
 	 * Called when the Bookmarks DB is updated by a bookmark insertion.

--- a/app/src/main/java/free/rm/skytube/businessobjects/db/PlaybackStatusDb.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/db/PlaybackStatusDb.java
@@ -9,7 +9,9 @@ import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
@@ -26,7 +28,8 @@ public class PlaybackStatusDb extends SQLiteOpenHelperEx {
 	private int updateCounter = 0;
 	private static final String DATABASE_NAME = "playbackhistory.db";
 
-	private List<VideoPlayStatusUpdateListener> listeners = new ArrayList<>();
+	private final Set<VideoPlayStatusUpdateListener> listeners = new HashSet<>();
+
 	public static synchronized PlaybackStatusDb getPlaybackStatusDb() {
 		if (playbackStatusDb == null) {
 			playbackStatusDb = new PlaybackStatusDb(SkyTubeApp.getContext());
@@ -206,9 +209,7 @@ public class PlaybackStatusDb extends SQLiteOpenHelperEx {
 	}
 
 	public void addListener(VideoPlayStatusUpdateListener listener) {
-		if(!listeners.contains(listener)) {
-			listeners.add(listener);
-		}
+		listeners.add(listener);
 	}
 
 	public void removeListener(VideoPlayStatusUpdateListener listener) {

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -88,8 +88,6 @@ public class MainActivity extends BaseActivity {
 	private PlaylistVideosFragment  playlistVideosFragment;
 	private VideoBlockerPlugin      videoBlockerPlugin;
 
-	private FragmentEx currentFragment;
-
 	private boolean dontAddToBackStack = false;
 
 	/** Set to true of the UpdatesCheckerTask has run; false otherwise. */
@@ -198,7 +196,6 @@ public class MainActivity extends BaseActivity {
 				mainFragment.setArguments(args);
 			}
 			getSupportFragmentManager().beginTransaction().add(R.id.fragment_container, mainFragment).commit();
-			currentFragment = mainFragment;
 		} else {
 			Logger.i(MainActivity.this, "mainFragment already exists, action:"+action+" fragment:"+mainFragment +", manager:"+mainFragment.getFragmentManager() +", support="+getSupportFragmentManager());
 		}
@@ -351,12 +348,6 @@ public class MainActivity extends BaseActivity {
 	}
 
 
-	@Override
-	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-		super.onActivityResult(requestCode, resultCode, data);
-	}
-
-
 	/**
 	 * Display the Enter Video URL dialog.
 	 */
@@ -446,7 +437,6 @@ public class MainActivity extends BaseActivity {
 		else
 			dontAddToBackStack = false;
 		transaction.commit();
-		currentFragment = fragment;
 	}
 
 
@@ -470,7 +460,6 @@ public class MainActivity extends BaseActivity {
 		channelBrowserFragment = new ChannelBrowserFragment();
 		channelBrowserFragment.getChannelPlaylistsFragment().setMainActivityListener(this);
 		channelBrowserFragment.setArguments(args);
-		currentFragment = channelBrowserFragment;
 		switchToFragment(channelBrowserFragment);
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -591,6 +591,6 @@ public class MainActivity extends BaseActivity {
 	@Override
 	public void refreshSubscriptionsFeedVideos() {
 		SubscriptionsFeedFragment.unsetFlag(SubscriptionsFeedFragment.FLAG_REFRESH_FEED_FROM_CACHE);
-		mainFragment.getSubscriptionsFeedFragment().refreshFeedFromCache();
+		mainFragment.refreshSubscriptionsFeedVideos();
 	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/MainActivity.java
@@ -288,8 +288,7 @@ public class MainActivity extends BaseActivity {
 			public boolean onQueryTextChange(final String newText) {
 				Logger.d(MainActivity.this, "on query text change: %s", newText);
 				// if the user does not want to have the search string saved, then skip the below...
-				if (SkyTubeApp.getPreferenceManager().getBoolean(getString(R.string.pref_key_disable_search_history), false)
-						||  newText == null) {
+				if (newText == null || SkyTubeApp.getSettings().isDisableSearchHistory()) {
 					return false;
 				}
 
@@ -313,7 +312,7 @@ public class MainActivity extends BaseActivity {
 
 			@Override
 			public boolean onQueryTextSubmit(String query) {
-				if(!SkyTubeApp.getPreferenceManager().getBoolean(SkyTubeApp.getStr(R.string.pref_key_disable_search_history), false)) {
+				if(!SkyTubeApp.getSettings().isDisableSearchHistory()) {
 					// Save this search string into the Search History Database (for Suggestions)
 					SearchHistoryDb.getSearchHistoryDb().insertSearchText(query);
 				}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/OrderableVideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/OrderableVideoGridAdapter.java
@@ -29,8 +29,7 @@ import free.rm.skytube.businessobjects.interfaces.OrderableDatabase;
 public class OrderableVideoGridAdapter extends VideoGridAdapter implements ItemTouchHelperAdapter {
 	private OrderableDatabase database = null;
 
-	public OrderableVideoGridAdapter(Context context, OrderableDatabase database) {
-		super(context);
+	public OrderableVideoGridAdapter(OrderableDatabase database) {
 		this.database = database;
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/PlaylistViewHolder.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/PlaylistViewHolder.java
@@ -70,7 +70,8 @@ class PlaylistViewHolder extends RecyclerView.ViewHolder {
 		this.playlistClickListener = playlistClickListener;
 	}
 
-	void setPlaylist(final YouTubePlaylist playlist, Context context) {
+	void setPlaylist(final YouTubePlaylist playlist) {
+		Context context = itemView.getContext();
 		Glide.with(context)
 						.load(playlist.getThumbnailUrl())
 						.apply(new RequestOptions().placeholder(R.drawable.thumbnail_default))

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/PlaylistsGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/PlaylistsGridAdapter.java
@@ -56,7 +56,7 @@ public class PlaylistsGridAdapter extends RecyclerViewAdapterEx<YouTubePlaylist,
 	@Override
 	public void onBindViewHolder(PlaylistViewHolder viewHolder, int position) {
 		if (viewHolder != null) {
-			viewHolder.setPlaylist(get(position), getContext());
+			viewHolder.setPlaylist(get(position));
 		}
 
 		// if it reached the bottom of the list, then try to get the next page of videos

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/RecyclerViewAdapterEx.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/RecyclerViewAdapterEx.java
@@ -23,7 +23,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
+import free.rm.skytube.app.Utils;
 import free.rm.skytube.businessobjects.utils.Predicate;
 
 /**
@@ -32,15 +34,13 @@ import free.rm.skytube.businessobjects.utils.Predicate;
 public abstract class RecyclerViewAdapterEx<T, HolderType extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<HolderType> {
 
 	private Context context;
-	protected List<T> list;
+	protected final List<T> list = new ArrayList<>();
 
-	public RecyclerViewAdapterEx(Context context) {
-		this(context, new ArrayList<T>());
+	public RecyclerViewAdapterEx() {
 	}
 
-	public RecyclerViewAdapterEx(Context context, List<T> list) {
+	public RecyclerViewAdapterEx(Context context) {
 		this.context  = context;
-		this.list     = list;
 	}
 
 	public Context getContext() {

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/SubsAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/SubsAdapter.java
@@ -181,7 +181,7 @@ public class SubsAdapter extends RecyclerViewAdapterEx<ChannelView, SubsAdapter.
 		}
 
 		void updateInfo(ChannelView channel) {
-			Glide.with(getContext().getApplicationContext())
+			Glide.with(itemView.getContext().getApplicationContext())
 					.load(channel.getThumbnailUrl())
 					.apply(new RequestOptions().placeholder(R.drawable.channel_thumbnail_default))
 					.into(thumbnailImageView);

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/SubsAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/SubsAdapter.java
@@ -29,7 +29,9 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import free.rm.skytube.R;
 import free.rm.skytube.businessobjects.YouTube.POJOs.ChannelView;
@@ -44,7 +46,7 @@ public class SubsAdapter extends RecyclerViewAdapterEx<ChannelView, SubsAdapter.
 
 	private static final String TAG = SubsAdapter.class.getSimpleName();
 	private static SubsAdapter subsAdapter = null;
-	private MainActivityListener listener;
+	private Set<MainActivityListener> listeners = new HashSet<>();
 
 	private String searchText;
 
@@ -68,8 +70,12 @@ public class SubsAdapter extends RecyclerViewAdapterEx<ChannelView, SubsAdapter.
 		return subsAdapter;
 	}
 
-	public void setListener(MainActivityListener listener) {
-		this.listener = listener;
+	public void addListener(MainActivityListener listener) {
+		this.listeners.add(listener);
+	}
+
+	public void removeListener(MainActivityListener listener) {
+		this.listeners.remove(listener);
 	}
 
 	/**
@@ -175,8 +181,9 @@ public class SubsAdapter extends RecyclerViewAdapterEx<ChannelView, SubsAdapter.
 			channel = null;
 
 			rowView.setOnClickListener(v -> {
-				if (listener instanceof MainActivityListener)
+				for (MainActivityListener listener: listeners) {
 					listener.onChannelClick(channel.getId());
+				}
 			});
 		}
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
@@ -89,8 +89,8 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<CardData, GridViewHo
 	 *
 	 * @param context	Context.
 	 */
-	public VideoGridAdapter(Context context) {
-		super(context);
+	public VideoGridAdapter() {
+		super();
 		this.getYouTubeVideos = null;
 		PlaybackStatusDb.getPlaybackStatusDb().addListener(this);
 	}
@@ -158,7 +158,8 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<CardData, GridViewHo
 
 	@Override
 	public GridViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-		View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.video_cell, parent, false);
+		setContext(parent.getContext());
+		View v = LayoutInflater.from(getContext()).inflate(R.layout.video_cell, parent, false);
 		final GridViewHolder gridViewHolder = new GridViewHolder(v, listener, showChannelInfo);
 		return gridViewHolder;
 	}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
@@ -43,6 +43,7 @@ import free.rm.skytube.gui.businessobjects.MainActivityListener;
  */
 public class VideoGridAdapter extends RecyclerViewAdapterEx<CardData, GridViewHolder> implements VideoPlayStatusUpdateListener {
 
+
 	public interface Callback {
 		void onVideoGridUpdated(int newVideoListSize);
 	}
@@ -92,6 +93,10 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<CardData, GridViewHo
 		super(context);
 		this.getYouTubeVideos = null;
 		PlaybackStatusDb.getPlaybackStatusDb().addListener(this);
+	}
+
+	public void onDestroy() {
+		PlaybackStatusDb.getPlaybackStatusDb().removeListener(this);
 	}
 
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/adapters/VideoGridAdapter.java
@@ -97,6 +97,8 @@ public class VideoGridAdapter extends RecyclerViewAdapterEx<CardData, GridViewHo
 
 	public void onDestroy() {
 		PlaybackStatusDb.getPlaybackStatusDb().removeListener(this);
+		this.listener = null;
+		this.videoGridUpdated = null;
 	}
 
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
@@ -92,6 +92,7 @@ public abstract class BaseVideosGridFragment extends TabFragment implements Swip
 	public void onDestroy() {
 		super.onDestroy();
 		videoGridAdapter.onDestroy();
+		videoGridAdapter = null;
 	}
 
 	@Override

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
@@ -81,6 +81,12 @@ public abstract class BaseVideosGridFragment extends TabFragment implements Swip
 	}
 
 	@Override
+	public void onDestroy() {
+		super.onDestroy();
+		videoGridAdapter.onDestroy();
+	}
+
+	@Override
 	public void onFragmentSelected() {
 		super.onFragmentSelected();
 		videoGridAdapter.initializeList();

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/BaseVideosGridFragment.java
@@ -37,26 +37,34 @@ import free.rm.skytube.gui.fragments.VideosGridFragment;
  */
 public abstract class BaseVideosGridFragment extends TabFragment implements SwipeRefreshLayout.OnRefreshListener {
 
-	protected final VideoGridAdapter  videoGridAdapter;
+	protected VideoGridAdapter  videoGridAdapter;
 	private int updateCount = 0;
 
 	@BindView(R.id.swipeRefreshLayout)
 	protected SwipeRefreshLayout swipeRefreshLayout;
 
-	public BaseVideosGridFragment(VideoGridAdapter videoGrid) {
-		this.videoGridAdapter = videoGrid;
+	public BaseVideosGridFragment() {
+	}
+
+	protected void setVideoGridAdapter(VideoGridAdapter adapter) {
+		this.videoGridAdapter = adapter;
 	}
 
 	@Nullable
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-		videoGridAdapter.setContext(getActivity());
+		if (videoGridAdapter == null) {
+			videoGridAdapter = new VideoGridAdapter();
+		}
 
 		View view = inflater.inflate(getLayoutResource(), container, false);
 
 		ButterKnife.bind(this, view);
 		swipeRefreshLayout.setOnRefreshListener(this);
 
+		if (isFragmentSelected()) {
+			videoGridAdapter.initializeList();
+		}
 		return view;
 	}
 
@@ -89,7 +97,9 @@ public abstract class BaseVideosGridFragment extends TabFragment implements Swip
 	@Override
 	public void onFragmentSelected() {
 		super.onFragmentSelected();
-		videoGridAdapter.initializeList();
+		if (videoGridAdapter != null) {
+			videoGridAdapter.initializeList();
+		}
 	}
 
 	/**

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/OrderableVideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/fragments/OrderableVideosGridFragment.java
@@ -14,8 +14,7 @@ import free.rm.skytube.gui.fragments.VideosGridFragment;
  * A VideosGridFragment that supports reordering of the videos in the Grid.
  */
 public abstract class OrderableVideosGridFragment extends VideosGridFragment {
-	public OrderableVideosGridFragment(OrderableVideoGridAdapter orderableVideoGridAdapter) {
-		super(orderableVideoGridAdapter);
+	public OrderableVideosGridFragment() {
 	}
 
 	@Override

--- a/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
@@ -17,7 +17,10 @@
 
 package free.rm.skytube.gui.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.view.View;
 
@@ -90,7 +93,18 @@ public class BookmarksFragment extends OrderableVideosGridFragment implements Bo
 	public String getFragmentName() {
 		return SkyTubeApp.getStr(R.string.bookmarks);
 	}
-	
+
+	@Override
+	public void onAttach(@NonNull Context context) {
+		super.onAttach(context);
+		BookmarksDb.getBookmarksDb().addListener(this);
+	}
+
+	@Override
+	public void onDetach() {
+		super.onDetach();
+		BookmarksDb.getBookmarksDb().removeListener(this);
+	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
@@ -22,7 +22,10 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import butterknife.BindView;
 import free.rm.skytube.R;
@@ -43,14 +46,15 @@ public class BookmarksFragment extends OrderableVideosGridFragment implements Bo
 	View noBookmarkedVideosText;
 
 	public BookmarksFragment() {
-		super(new OrderableVideoGridAdapter(null, BookmarksDb.getBookmarksDb()));
 	}
 
 	@Override
-	public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, @Nullable Bundle savedInstanceState) {
+		setVideoGridAdapter(new OrderableVideoGridAdapter(BookmarksDb.getBookmarksDb()));
+		View view = super.onCreateView(inflater, container, savedInstanceState);
 		swipeRefreshLayout.setEnabled(false);
 		populateList();
+		return view;
 	}
 
 	private void populateList() {
@@ -92,6 +96,16 @@ public class BookmarksFragment extends OrderableVideosGridFragment implements Bo
 	@Override
 	public String getFragmentName() {
 		return SkyTubeApp.getStr(R.string.bookmarks);
+	}
+
+	@Override
+	public int getPriority() {
+		return 3;
+	}
+
+	@Override
+	public String getBundleKey() {
+		return MainFragment.BOOKMARKS_FRAGMENT;
 	}
 
 	@Override

--- a/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/BookmarksFragment.java
@@ -53,6 +53,7 @@ public class BookmarksFragment extends OrderableVideosGridFragment implements Bo
 		setVideoGridAdapter(new OrderableVideoGridAdapter(BookmarksDb.getBookmarksDb()));
 		View view = super.onCreateView(inflater, container, savedInstanceState);
 		swipeRefreshLayout.setEnabled(false);
+		BookmarksDb.getBookmarksDb().addListener(this);
 		populateList();
 		return view;
 	}
@@ -109,15 +110,9 @@ public class BookmarksFragment extends OrderableVideosGridFragment implements Bo
 	}
 
 	@Override
-	public void onAttach(@NonNull Context context) {
-		super.onAttach(context);
-		BookmarksDb.getBookmarksDb().addListener(this);
-	}
-
-	@Override
-	public void onDetach() {
-		super.onDetach();
+	public void onDestroyView() {
 		BookmarksDb.getBookmarksDb().removeListener(this);
+		super.onDestroyView();
 	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/free/rm/skytube/gui/fragments/ChannelPlaylistsFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/ChannelPlaylistsFragment.java
@@ -72,4 +72,8 @@ public class ChannelPlaylistsFragment extends VideosGridFragment implements Play
 		return null;
 	}
 
+	@Override
+	public int getPriority() {
+		return 6;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/ChannelVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/ChannelVideosFragment.java
@@ -64,5 +64,8 @@ public class ChannelVideosFragment extends VideosGridFragment {
 		return SkyTubeApp.getStr(R.string.videos);
 	}
 
-
+	@Override
+	public int getPriority() {
+		return 0;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
@@ -31,20 +31,15 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 		setVideoGridAdapter(new OrderableVideoGridAdapter(DownloadedVideosDb.getVideoDownloadsDb()));
 		View view = super.onCreateView(inflater, container, savedInstanceState);
 		swipeRefreshLayout.setEnabled(false);
+		DownloadedVideosDb.getVideoDownloadsDb().addListener(this);
 		populateList();
 		return view;
 	}
 
 	@Override
-	public void onAttach(@NonNull Context context) {
-		super.onAttach(context);
-		DownloadedVideosDb.getVideoDownloadsDb().addListener(this);
-	}
-
-	@Override
-	public void onDetach() {
-		super.onDetach();
+	public void onDestroyView() {
 		DownloadedVideosDb.getVideoDownloadsDb().removeListener(this);
+		super.onDestroyView();
 	}
 
 	@Override

--- a/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
@@ -1,6 +1,9 @@
 package free.rm.skytube.gui.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.view.View;
 
@@ -31,6 +34,17 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 		populateList();
 	}
 
+	@Override
+	public void onAttach(@NonNull Context context) {
+		super.onAttach(context);
+		DownloadedVideosDb.getVideoDownloadsDb().addListener(this);
+	}
+
+	@Override
+	public void onDetach() {
+		super.onDetach();
+		DownloadedVideosDb.getVideoDownloadsDb().removeListener(this);
+	}
 
 	@Override
 	protected int getLayoutResource() {

--- a/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/DownloadedVideosFragment.java
@@ -5,7 +5,10 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import butterknife.BindView;
 import free.rm.skytube.R;
@@ -23,15 +26,13 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 	@BindView(R.id.noDownloadedVideosText)
 	View noDownloadedVideosText;
 
-	public DownloadedVideosFragment() {
-		super(new OrderableVideoGridAdapter(null, DownloadedVideosDb.getVideoDownloadsDb()));
-	}
-
 	@Override
-	public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, @Nullable Bundle savedInstanceState) {
+		setVideoGridAdapter(new OrderableVideoGridAdapter(DownloadedVideosDb.getVideoDownloadsDb()));
+		View view = super.onCreateView(inflater, container, savedInstanceState);
 		swipeRefreshLayout.setEnabled(false);
 		populateList();
+		return view;
 	}
 
 	@Override
@@ -63,13 +64,21 @@ public class DownloadedVideosFragment extends OrderableVideosGridFragment implem
 		return SkyTubeApp.getStr(R.string.downloads);
 	}
 
+	@Override
+	public int getPriority() {
+		return 4;
+	}
+
+	@Override
+	public String getBundleKey() {
+		return MainFragment.DOWNLOADED_VIDEOS_FRAGMENT;
+	}
 
 	@Override
 	public void onDownloadedVideosUpdated() {
 		populateList();
 		videoGridAdapter.refresh(true);
 	}
-
 
 	private void populateList() {
 		new PopulateDownloadsTask().executeInParallel();

--- a/app/src/main/java/free/rm/skytube/gui/fragments/FeaturedVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/FeaturedVideosFragment.java
@@ -37,4 +37,13 @@ public class FeaturedVideosFragment extends VideosGridFragment {
 		return SkyTubeApp.getStr(R.string.featured);
 	}
 
+	@Override
+	public int getPriority() {
+		return 0;
+	}
+
+	@Override
+	public String getBundleKey() {
+		return MainFragment.FEATURED_VIDEOS_FRAGMENT;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -21,6 +21,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -249,8 +250,17 @@ public class MainFragment extends FragmentEx {
 			Logger.d(this, "MAINFRAGMENT RESUMED " + tabLayout.getSelectedTabPosition());
 			videoGridFragmentsList.get(tabLayout.getSelectedTabPosition()).onFragmentSelected();
 		}
+		FragmentActivity activity = getActivity();
+		subsAdapter.setContext(activity);
+		subsAdapter.setListener((MainActivityListener)activity);
 	}
 
+	@Override
+	public void onPause() {
+		super.onPause();
+		subsAdapter.setListener(null);
+		subsAdapter.setContext(null);
+	}
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -1,7 +1,6 @@
 package free.rm.skytube.gui.fragments;
 
 import android.content.SharedPreferences;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
@@ -9,10 +8,9 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AutoCompleteTextView;
-import android.widget.EditText;
 import android.widget.ImageView;
-import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -56,13 +54,6 @@ public class MainFragment extends FragmentEx {
 	private DrawerLayout 				subsDrawerLayout = null;
 	private SearchView 					subSearchView = null;
 
-	/** List of fragments that will be displayed as tabs. */
-	private List<VideosGridFragment>	videoGridFragmentsList = new ArrayList<>();
-	private FeaturedVideosFragment		featuredVideosFragment = null;
-	private MostPopularVideosFragment	mostPopularVideosFragment = null;
-	private SubscriptionsFeedFragment   subscriptionsFeedFragment = null;
-	private BookmarksFragment			bookmarksFragment = null;
-	private DownloadedVideosFragment    downloadedVideosFragment = null;
 
 	// Constants for saving the state of this Fragment's child Fragments
 	public static final String FEATURED_VIDEOS_FRAGMENT = "MainFragment.featuredVideosFragment";
@@ -76,20 +67,6 @@ public class MainFragment extends FragmentEx {
 
 	public static final String SHOULD_SELECTED_FEED_TAB = "MainFragment.SHOULD_SELECTED_FEED_TAB";
 
-	@Override
-	public void onCreate(@Nullable Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
-		if(savedInstanceState != null) {
-			featuredVideosFragment = (FeaturedVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, FEATURED_VIDEOS_FRAGMENT);
-			mostPopularVideosFragment = (MostPopularVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, MOST_POPULAR_VIDEOS_FRAGMENT);
-			subscriptionsFeedFragment = (SubscriptionsFeedFragment)getChildFragmentManager().getFragment(savedInstanceState, SUBSCRIPTIONS_FEED_FRAGMENT);
-			bookmarksFragment = (BookmarksFragment) getChildFragmentManager().getFragment(savedInstanceState, BOOKMARKS_FRAGMENT);
-			downloadedVideosFragment = (DownloadedVideosFragment) getChildFragmentManager().getFragment(savedInstanceState, DOWNLOADED_VIDEOS_FRAGMENT);
-		}
-	}
-
-
 	@Nullable
 	@Override
 	public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -98,7 +75,7 @@ public class MainFragment extends FragmentEx {
 		// For the non-oss version, when using a Chromecast, returning to this fragment from another fragment that uses
 		// CoordinatorLayout results in the SlidingUpPanel to be positioned improperly. We need to redraw the panel
 		// to fix this. The oss version just has a no-op method.
-		((BaseActivity)getActivity()).redrawPanel();
+		((BaseActivity) getActivity()).redrawPanel();
 
 		// setup the toolbar / actionbar
 		Toolbar toolbar = view.findViewById(R.id.toolbar);
@@ -110,10 +87,10 @@ public class MainFragment extends FragmentEx {
 
 		subsDrawerLayout = view.findViewById(R.id.subs_drawer_layout);
 		subsDrawerToggle = new ActionBarDrawerToggle(
-						getActivity(),
-						subsDrawerLayout,
-						R.string.app_name,
-						R.string.app_name
+				getActivity(),
+				subsDrawerLayout,
+				R.string.app_name,
+				R.string.app_name
 		);
 		subsDrawerToggle.setDrawerIndicatorEnabled(true);
 		final ActionBar actionBar = getSupportActionBar();
@@ -137,7 +114,7 @@ public class MainFragment extends FragmentEx {
 		} else {
 			subsAdapter.setContext(getActivity());
 		}
-		subsAdapter.setListener((MainActivityListener)getActivity());
+		subsAdapter.setListener((MainActivityListener) getActivity());
 
 		subsListView.setLayoutManager(new LinearLayoutManager(getActivity()));
 		subsListView.setAdapter(subsAdapter);
@@ -160,15 +137,18 @@ public class MainFragment extends FragmentEx {
 			@Override
 			public boolean onClose() {
 
-				Logger.i(this,"closed search");
+				Logger.i(this, "closed search");
 
 				return false;
 			}
 		});
 
 		videosPagerAdapter = new VideosPagerAdapter(getChildFragmentManager());
+		videosPagerAdapter.init(savedInstanceState);
+
 		viewPager = view.findViewById(R.id.pager);
-		viewPager.setOffscreenPageLimit(videoGridFragmentsList.size() > 3 ? videoGridFragmentsList.size() - 1 : videoGridFragmentsList.size());
+		final int tabCount = videosPagerAdapter.getCount();
+		viewPager.setOffscreenPageLimit(tabCount > 3 ? tabCount - 1 : tabCount);
 		viewPager.setAdapter(videosPagerAdapter);
 
 		tabLayout = view.findViewById(R.id.tab_layout);
@@ -178,19 +158,20 @@ public class MainFragment extends FragmentEx {
 			@Override
 			public void onTabSelected(TabLayout.Tab tab) {
 				viewPager.setCurrentItem(tab.getPosition());
-				videoGridFragmentsList.get(tab.getPosition()).onFragmentSelected();
+
+				videosPagerAdapter.notifyTab(tab, true);
 			}
 
 			@Override
 			public void onTabUnselected(TabLayout.Tab tab) {
-				videoGridFragmentsList.get(tab.getPosition()).onFragmentUnselected();
+				videosPagerAdapter.notifyTab(tab, false);
 			}
 
 			@Override
 			public void onTabReselected(TabLayout.Tab tab) {
 				//When current tab reselected scroll to the top of the video list
-				VideosGridFragment fragment = videoGridFragmentsList.get(tab.getPosition());
-				if(fragment != null && fragment.gridView != null) {
+				VideosGridFragment fragment = videosPagerAdapter.getTab(tab);
+				if (fragment != null && fragment.gridView != null) {
 					fragment.gridView.smoothScrollToPosition(TOP_LIST_INDEX);
 				}
 			}
@@ -201,23 +182,23 @@ public class MainFragment extends FragmentEx {
 
 		// If the app is being opened via the Notification that new videos from Subscribed channels have been found, select the Subscriptions Feed Fragment
 		Bundle args = getArguments();
-		if(args != null && args.getBoolean(SHOULD_SELECTED_FEED_TAB, false)) {
-			viewPager.setCurrentItem(videoGridFragmentsList.indexOf(subscriptionsFeedFragment));
+		if (args != null && args.getBoolean(SHOULD_SELECTED_FEED_TAB, false)) {
+			viewPager.setCurrentItem(videosPagerAdapter.getIndexOf(SubscriptionsFeedFragment.class));
 		} else {
 			String defaultTab = sp.getString(getString(R.string.pref_key_default_tab_name), null);
-			String[] tabListValues = SkyTubeApp.getStringArray(R.array.tab_list_values);
+			String[] tabListValues = getTabListValues();
 
-			if(defaultTab == null) {
+			if (defaultTab == null) {
 				int defaultTabNum = Integer.parseInt(sp.getString(getString(R.string.pref_key_default_tab), "0"));
 				defaultTab = tabListValues[defaultTabNum];
-				sp.edit().putString(getString(R.string.pref_key_default_tab_name), tabListValues[defaultTabNum]).apply();
+				sp.edit().putString(getString(R.string.pref_key_default_tab_name), defaultTab).apply();
 			}
 
 			// Create a list of non-hidden fragments in order to default to the proper tab
-			Set<String> hiddenFragments = SkyTubeApp.getPreferenceManager().getStringSet(getString(R.string.pref_key_hide_tabs), new HashSet<>());
+			Set<String> hiddenFragments = SkyTubeApp.getSettings().getHiddenTabs();
 			List<String> shownFragmentList = new ArrayList<>();
-			for(int i=0;i<tabListValues.length;i++) {
-				if(!hiddenFragments.contains(tabListValues[i]))
+			for (int i = 0; i < tabListValues.length; i++) {
+				if (!hiddenFragments.contains(tabListValues[i]))
 					shownFragmentList.add(tabListValues[i]);
 			}
 			viewPager.setCurrentItem(shownFragmentList.indexOf(defaultTab));
@@ -226,11 +207,21 @@ public class MainFragment extends FragmentEx {
 		// Set the current viewpager fragment as selected, as when the Activity is recreated, the Fragment
 		// won't know that it's selected. When the Feeds fragment is the default tab, this will prevent the
 		// refresh dialog from showing when an automatic refresh happens.
-		videoGridFragmentsList.get(viewPager.getCurrentItem()).onFragmentSelected();
+		videosPagerAdapter.selectTabAtPosition(viewPager.getCurrentItem());
 
 		return view;
 	}
 
+	private static String[] getTabListValues() {
+		return SkyTubeApp.getStringArray(R.array.tab_list_values);
+	}
+
+	@Override
+	public void onDestroy() {
+		videosPagerAdapter = null;
+		viewPager = null;
+		super.onDestroy();
+	}
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
@@ -246,13 +237,13 @@ public class MainFragment extends FragmentEx {
 
 		// when the MainFragment is resumed (e.g. after Preferences is minimized), inform the
 		// current fragment that it is selected.
-		if (videoGridFragmentsList != null  &&  tabLayout != null) {
+		if (videosPagerAdapter != null && tabLayout != null) {
 			Logger.d(this, "MAINFRAGMENT RESUMED " + tabLayout.getSelectedTabPosition());
-			videoGridFragmentsList.get(tabLayout.getSelectedTabPosition()).onFragmentSelected();
+			videosPagerAdapter.selectTabAtPosition(tabLayout.getSelectedTabPosition());
 		}
 		FragmentActivity activity = getActivity();
 		subsAdapter.setContext(activity);
-		subsAdapter.setListener((MainActivityListener)activity);
+		subsAdapter.setListener((MainActivityListener) activity);
 	}
 
 	@Override
@@ -275,52 +266,98 @@ public class MainFragment extends FragmentEx {
 	}
 
 
-	private class VideosPagerAdapter extends FragmentPagerAdapter {
+	private static class VideosPagerAdapter extends FragmentPagerAdapter {
+		private final List<VideosGridFragment> videoGridFragmentsList = new ArrayList<>();
+		private final FragmentManager fragmentManager;
 
 		public VideosPagerAdapter(FragmentManager fm) {
-			super(fm);
+			// TODO: Investigate, if we need this
+			super(fm, BEHAVIOR_SET_USER_VISIBLE_HINT);
+			this.fragmentManager = fm;
+		}
 
-			// initialise fragments
-			if (featuredVideosFragment == null)
-				featuredVideosFragment = new FeaturedVideosFragment();
-
-			if (mostPopularVideosFragment == null)
-				mostPopularVideosFragment = new MostPopularVideosFragment();
-
-			if (subscriptionsFeedFragment == null)
-				subscriptionsFeedFragment = new SubscriptionsFeedFragment();
-
-			if (bookmarksFragment == null) {
-				bookmarksFragment = new BookmarksFragment();
-				BookmarksDb.getBookmarksDb().addListener(bookmarksFragment);
-			}
-
-			if(downloadedVideosFragment == null) {
-				downloadedVideosFragment = new DownloadedVideosFragment();
-				DownloadedVideosDb.getVideoDownloadsDb().setListener(downloadedVideosFragment);
-			}
-
-			Set<String> hiddenFragments = SkyTubeApp.getPreferenceManager().getStringSet(getString(R.string.pref_key_hide_tabs), new HashSet<>());
-
-			// add fragments to list:  do NOT forget to ***UPDATE*** @string/tab_list and @string/tab_list_values
+		public void init(@NonNull Bundle savedInstanceState) {
 			videoGridFragmentsList.clear();
-			if(!hiddenFragments.contains(FEATURED_VIDEOS_FRAGMENT))
-				videoGridFragmentsList.add(featuredVideosFragment);
-			if(!hiddenFragments.contains(MOST_POPULAR_VIDEOS_FRAGMENT))
-				videoGridFragmentsList.add(mostPopularVideosFragment);
-			if(!hiddenFragments.contains(SUBSCRIPTIONS_FEED_FRAGMENT))
-				videoGridFragmentsList.add(subscriptionsFeedFragment);
-			if(!hiddenFragments.contains(BOOKMARKS_FRAGMENT))
-				videoGridFragmentsList.add(bookmarksFragment);
-			if(!hiddenFragments.contains(DOWNLOADED_VIDEOS_FRAGMENT))
-				videoGridFragmentsList.add(downloadedVideosFragment);
+			Set<String> hiddenTabs = SkyTubeApp.getSettings().getHiddenTabs();
+			for (String key : getTabListValues()) {
+				if (!hiddenTabs.contains(key)) {
+					VideosGridFragment fragment = savedInstanceState != null ? (VideosGridFragment) fragmentManager.getFragment(savedInstanceState, key) : null;
+					if (fragment == null) {
+						fragment = create(key);
+					}
+					if (fragment != null) {
+						videoGridFragmentsList.add(fragment);
+					}
+				}
+			}
+			notifyDataSetChanged();
+		}
 
+		VideosGridFragment create(String key) {
+			// add fragments to list:  do NOT forget to ***UPDATE*** @string/tab_list and @string/tab_list_values
+			if (MOST_POPULAR_VIDEOS_FRAGMENT.equals(key)) {
+				return new MostPopularVideosFragment();
+			}
+			if (FEATURED_VIDEOS_FRAGMENT.equals(key)) {
+				return new FeaturedVideosFragment();
+			}
+			if (SUBSCRIPTIONS_FEED_FRAGMENT.equals(key)) {
+				return new SubscriptionsFeedFragment();
+			}
+			if (BOOKMARKS_FRAGMENT.equals(key)) {
+				return new BookmarksFragment();
+			}
+			if (DOWNLOADED_VIDEOS_FRAGMENT.equals(key)) {
+				return new DownloadedVideosFragment();
+			}
+			return null;
+		}
 
+		public <T extends VideosGridFragment> int getIndexOf(Class<T> clazz) {
+			for (int i = 0; i < videoGridFragmentsList.size(); i++) {
+				if (clazz.isInstance(videoGridFragmentsList.get(i))) {
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		public <T extends VideosGridFragment> T getTabOf(Class<T> clazz) {
+			for (VideosGridFragment fragment : videoGridFragmentsList) {
+				if (clazz.isInstance(fragment)) {
+					return clazz.cast(fragment);
+				}
+			}
+			return null;
 		}
 
 		@Override
 		public int getCount() {
 			return videoGridFragmentsList.size();
+		}
+
+		public VideosGridFragment getTab(TabLayout.Tab tab) {
+			return videoGridFragmentsList.get(tab.getPosition());
+		}
+
+		public boolean notifyTab(TabLayout.Tab tab, boolean onSelect) {
+			VideosGridFragment fragment = videoGridFragmentsList.get(tab.getPosition());
+			if (fragment != null) {
+				if (onSelect) {
+					fragment.onFragmentSelected();
+				} else {
+					fragment.onFragmentUnselected();
+				}
+				return true;
+			}
+			return false;
+		}
+
+		public void selectTabAtPosition(int position) {
+			VideosGridFragment fragment = videoGridFragmentsList.get(position);
+			if (fragment != null) {
+				fragment.onFragmentSelected();
+			}
 		}
 
 		@Override
@@ -333,24 +370,22 @@ public class MainFragment extends FragmentEx {
 			return videoGridFragmentsList.get(position).getFragmentName();
 		}
 
+		void onSaveInstanceState(Bundle outState) {
+			for (VideosGridFragment videosGridFragment : videoGridFragmentsList) {
+				String key = videosGridFragment.getBundleKey();
+				if (key != null) {
+					fragmentManager.putFragment(outState, key, videosGridFragment);
+				}
+			}
+		}
 	}
 
 	@Override
 	public void onSaveInstanceState(Bundle outState) {
-		if(featuredVideosFragment != null && featuredVideosFragment.isAdded())
-			getChildFragmentManager().putFragment(outState, FEATURED_VIDEOS_FRAGMENT, featuredVideosFragment);
-		if(mostPopularVideosFragment != null && mostPopularVideosFragment.isAdded())
-			getChildFragmentManager().putFragment(outState, MOST_POPULAR_VIDEOS_FRAGMENT, mostPopularVideosFragment);
-		if(subscriptionsFeedFragment != null && subscriptionsFeedFragment.isAdded())
-			getChildFragmentManager().putFragment(outState, SUBSCRIPTIONS_FEED_FRAGMENT, subscriptionsFeedFragment);
-		if(bookmarksFragment != null && bookmarksFragment.isAdded())
-			getChildFragmentManager().putFragment(outState, BOOKMARKS_FRAGMENT, bookmarksFragment);
-		if(downloadedVideosFragment != null && downloadedVideosFragment.isAdded())
-			getChildFragmentManager().putFragment(outState, DOWNLOADED_VIDEOS_FRAGMENT, downloadedVideosFragment);
+		videosPagerAdapter.onSaveInstanceState(outState);
 
 		super.onSaveInstanceState(outState);
 	}
-
 
 	/**
 	 * Returns true if the subscriptions drawer is opened.
@@ -359,7 +394,7 @@ public class MainFragment extends FragmentEx {
 		return subsDrawerLayout.isDrawerOpen(GravityCompat.START);
 	}
 
-	
+
 	/**
 	 * Close the subscriptions drawer.
 	 */
@@ -367,11 +402,13 @@ public class MainFragment extends FragmentEx {
 		subsDrawerLayout.closeDrawer(GravityCompat.START);
 	}
 
-	/*
-	 * Returns the SubscriptionsFeedFragment
-	 * @return {@link free.rm.skytube.gui.fragments.SubscriptionsFeedFragment}
+	/**
+	 * Refresh the SubscriptionsFeedFragment's feed.
 	 */
-	public SubscriptionsFeedFragment getSubscriptionsFeedFragment() {
-		return subscriptionsFeedFragment;
+	public void refreshSubscriptionsFeedVideos() {
+		SubscriptionsFeedFragment subscriptionsFeedFragment = videosPagerAdapter.getTabOf(SubscriptionsFeedFragment.class);
+		if (subscriptionsFeedFragment != null) {
+			subscriptionsFeedFragment.refreshFeedFromCache();
+		}
 	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MainFragment.java
@@ -114,7 +114,7 @@ public class MainFragment extends FragmentEx {
 		} else {
 			subsAdapter.setContext(getActivity());
 		}
-		subsAdapter.setListener((MainActivityListener) getActivity());
+		subsAdapter.addListener((MainActivityListener) getActivity());
 
 		subsListView.setLayoutManager(new LinearLayoutManager(getActivity()));
 		subsListView.setAdapter(subsAdapter);
@@ -217,6 +217,12 @@ public class MainFragment extends FragmentEx {
 	}
 
 	@Override
+	public void onDestroyView() {
+		subsAdapter.removeListener((MainActivityListener) getActivity());
+		super.onDestroyView();
+	}
+
+	@Override
 	public void onDestroy() {
 		videosPagerAdapter = null;
 		viewPager = null;
@@ -243,13 +249,11 @@ public class MainFragment extends FragmentEx {
 		}
 		FragmentActivity activity = getActivity();
 		subsAdapter.setContext(activity);
-		subsAdapter.setListener((MainActivityListener) activity);
 	}
 
 	@Override
 	public void onPause() {
 		super.onPause();
-		subsAdapter.setListener(null);
 		subsAdapter.setContext(null);
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/MostPopularVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/MostPopularVideosFragment.java
@@ -36,4 +36,13 @@ public class MostPopularVideosFragment extends VideosGridFragment {
 		return SkyTubeApp.getStr(R.string.most_popular);
 	}
 
+	@Override
+	public int getPriority() {
+		return 1;
+	}
+
+	@Override
+	public String getBundleKey() {
+		return MainFragment.MOST_POPULAR_VIDEOS_FRAGMENT;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/PlaylistVideosFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/PlaylistVideosFragment.java
@@ -111,4 +111,8 @@ public class PlaylistVideosFragment extends VideosGridFragment {
 		return youTubePlaylist.getId();
 	}
 
+	@Override
+	public int getPriority() {
+		return 0;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/SearchVideoGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/SearchVideoGridFragment.java
@@ -136,4 +136,8 @@ public class SearchVideoGridFragment extends VideosGridFragment {
 		return null;
 	}
 
+	@Override
+	public int getPriority() {
+		return 0;
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/SubscriptionsFeedFragment.java
@@ -303,6 +303,15 @@ public class SubscriptionsFeedFragment extends VideosGridFragment implements Get
 		return SkyTubeApp.getStr(R.string.feed);
 	}
 
+	@Override
+	public int getPriority() {
+		return 2;
+	}
+
+	@Override
+	public String getBundleKey() {
+		return MainFragment.SUBSCRIPTIONS_FEED_FRAGMENT;
+	}
 
 	@OnClick(R.id.importSubscriptionsButton)
 	public void importSubscriptions(View v) {

--- a/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
@@ -31,6 +31,7 @@ import com.bumptech.glide.Glide;
 import butterknife.BindView;
 import free.rm.skytube.R;
 import free.rm.skytube.businessobjects.VideoCategory;
+import free.rm.skytube.businessobjects.db.BookmarksDb;
 import free.rm.skytube.gui.businessobjects.MainActivityListener;
 import free.rm.skytube.gui.businessobjects.adapters.VideoGridAdapter;
 import free.rm.skytube.gui.businessobjects.fragments.BaseVideosGridFragment;
@@ -72,9 +73,10 @@ public abstract class VideosGridFragment extends BaseVideosGridFragment {
 
 
 	@Override
-	public void onDestroy() {
-		super.onDestroy();
+	public void onDestroyView() {
 		gridView.setAdapter(null);
+		videoGridAdapter.onDestroy();
+		super.onDestroyView();
 		Glide.get(getActivity()).clearMemory();
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
@@ -74,6 +74,7 @@ public abstract class VideosGridFragment extends BaseVideosGridFragment {
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
+		gridView.setAdapter(null);
 		Glide.get(getActivity()).clearMemory();
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/VideosGridFragment.java
@@ -17,6 +17,7 @@
 
 package free.rm.skytube.gui.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -43,10 +44,6 @@ public abstract class VideosGridFragment extends BaseVideosGridFragment {
 	protected RecyclerView	gridView;
 
 	public VideosGridFragment() {
-		super(new VideoGridAdapter(null));
-	}
-	public VideosGridFragment(VideoGridAdapter videoGrid) {
-		super(videoGrid);
 	}
 
 	@Override
@@ -106,4 +103,9 @@ public abstract class VideosGridFragment extends BaseVideosGridFragment {
 	 */
 	public abstract String getFragmentName();
 
+	public abstract int getPriority();
+
+	public String getBundleKey() {
+		return null;
+	}
 }


### PR DESCRIPTION
Add com.squareup.leakcanary to enable debugging of the memory leaks - and quickly fix a couple of them, caused by leaking listeners which retained activities and fragments.