### PR TITLE
Bump dependencies 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,8 +103,10 @@ dependencies {
     implementation 'com.github.moraisigor:slidingdrawer:1.7.1'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
-    implementation 'com.jakewharton:butterknife:10.2.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
+
+    implementation 'com.jakewharton:butterknife:10.2.3'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.3'
+    
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'joda-time:joda-time:2.10.6'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
@@ -119,14 +121,14 @@ dependencies {
     implementation 'com.github.hedzr:android-file-chooser:v1.2.0-final'
 
     // Android support modules
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.core:core:1.2.0'
+    implementation 'androidx.core:core:1.3.1'
     implementation 'androidx.preference:preference:1.1.1'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.multidex:multidex:2.0.1' // as we have over 65536 lines of code...
 
     // debugImplementation because LeakCanary should only run in debug builds.


### PR DESCRIPTION
  material from 1.1.0 to 1.2.1
  appcompat from 1.1.0 to 1.2.0
  play-services-cast-framework from 18.1.0 to 19.0.0
  core from 1.2.0 to 1.3.1
  gradle from 3.6.3 to 4.0.1
  constraintlayout from 1.1.3 to 2.0.1
  butterknife from 10.2.1 to 10.2.3
  butterknife-compiler from 10.2.1 to 10.2.3