### PR TITLE
Fix #834

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/YouTube/newpipe/NewPipeService.java
@@ -262,7 +262,11 @@ public class NewPipeService {
         VideoPagerWithChannel pager = getChannelPager(channelId);
         // get the channel, and add all the videos from the first page
         YouTubeChannel channel = pager.getChannel();
-        channel.getYouTubeVideos().addAll(pager.getNextPageAsVideos());
+        try {
+            channel.getYouTubeVideos().addAll(pager.getNextPageAsVideos());
+        } catch (NewPipeException e) {
+            Logger.e(this, "Unable to retrieve videos for "+channelId+", error: "+e.getMessage(), e);
+        }
         return channel;
     }
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/views/SubscribeButton.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/views/SubscribeButton.java
@@ -59,16 +59,17 @@ public class SubscribeButton extends AppCompatButton implements View.OnClickList
 		if(externalClickListener != null) {
 			externalClickListener.onClick(SubscribeButton.this);
 		}
-		// Only fetch videos for this channel if fetchChannelVideosOnSubscribe is true AND the channel is not subscribed to yet.
-		if(fetchChannelVideosOnSubscribe && !isUserSubscribed) {
-			if (NewPipeService.isPreferred()) {
-				new GetBulkSubscriptionVideosTask(channel.getId(), null).executeInParallel();
-			} else {
-				new GetChannelVideosTask(channel.getId(), null, false, null).executeInParallel();
+		if(channel != null) {
+			// Only fetch videos for this channel if fetchChannelVideosOnSubscribe is true AND the channel is not subscribed to yet.
+			if (fetchChannelVideosOnSubscribe && !isUserSubscribed) {
+				if (NewPipeService.isPreferred()) {
+					new GetBulkSubscriptionVideosTask(channel.getId(), null).executeInParallel();
+				} else {
+					new GetChannelVideosTask(channel.getId(), null, false, null).executeInParallel();
+				}
 			}
-		}
-		if(channel != null)
 			new SubscribeToChannelTask(SubscribeButton.this, channel).executeInParallel();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
 when  parsing channels, which doesnt have videos tab, NewPipeExtractor throws an exception, but this shouldn't be a blocker thing,

 catching the exception, and going further fix a couple of problems